### PR TITLE
docs: add townhall REST and MCP server documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ That's it! Your agents are now coordinating via Redis.
 
 > **Note:** `tt bootstrap` delegates to an AI agent to download Redis from GitHub and compile it for your machine. Alternatively: `brew install redis` (macOS) or `apt install redis-server` (Ubuntu).
 
+## 🌐 Programmatic Interfaces
+
+Tinytown also ships a `townhall` control plane binary with both REST and MCP interfaces.
+
+```bash
+# REST API (default: 127.0.0.1:8080)
+townhall rest
+
+# MCP over stdio
+townhall mcp-stdio
+
+# MCP over HTTP/SSE (default: REST port + 1)
+townhall mcp-http
+```
+
+REST OpenAPI spec: `docs/openapi/townhall-v1.yaml`
+
 ## 🏗️ Architecture
 
 Tinytown is built on **6 core concepts**:

--- a/docs/openapi/townhall-v1.yaml
+++ b/docs/openapi/townhall-v1.yaml
@@ -16,7 +16,7 @@ info:
     url: https://github.com/redis-field-engineering/tinytown
 
 servers:
-  - url: http://localhost:8787
+  - url: http://localhost:8080
     description: Local development server
 
 tags:
@@ -145,6 +145,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AgentActionResponse'
+
+  /v1/agents/prune:
+    post:
+      tags: [Agents]
+      summary: Prune stopped/error agents from active roster
+      operationId: pruneAgents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PruneRequest'
+      responses:
+        '200':
+          description: Agents pruned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PruneResponse'
 
 
   /v1/tasks/assign:

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -108,6 +108,8 @@ See [tt plan](./cli/plan.md) for the full task DSL.
 - **[Installation](./getting-started/installation.md)** — Get Tinytown running in 30 seconds
 - **[Quick Start](./getting-started/quickstart.md)** — Your first multi-agent workflow
 - **[Core Concepts](./concepts/overview.md)** — Understand Towns, Agents, Tasks, Messages, and Channels
+- **[Townhall REST API](./advanced/townhall-rest.md)** — HTTP control plane for automation
+- **[Townhall MCP Server](./advanced/townhall-mcp.md)** — MCP tools/resources/prompts for LLM clients
 - **[Coming from Gastown?](./gastown/migration.md)** — Migration guide for Gastown users
 
 ## Named After

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -53,4 +53,6 @@
 
 - [Custom Models](./advanced/custom-models.md)
 - [Redis Configuration](./advanced/redis.md)
+- [Townhall REST API](./advanced/townhall-rest.md)
+- [Townhall MCP Server](./advanced/townhall-mcp.md)
 - [API Reference](./advanced/api.md)

--- a/docs/src/advanced/api.md
+++ b/docs/src/advanced/api.md
@@ -4,6 +4,8 @@ The Tinytown Rust API for programmatic control.
 
 ## Quick Links
 
+- [Townhall REST API](./townhall-rest.md) — HTTP control plane daemon
+- [Townhall MCP Server](./townhall-mcp.md) — MCP tools/resources/prompts
 - [Full rustdoc](https://redis-field-engineering.github.io/tinytown/tinytown/) — Complete API documentation
 
 ## Core Types

--- a/docs/src/advanced/townhall-mcp.md
+++ b/docs/src/advanced/townhall-mcp.md
@@ -1,0 +1,73 @@
+# Townhall MCP Server
+
+Tinytown includes an MCP server in the `townhall` binary for LLM/tooling integrations.
+
+## Start MCP
+
+```bash
+# MCP over stdio (for local MCP clients)
+townhall mcp-stdio
+
+# MCP over HTTP/SSE
+townhall mcp-http
+
+# Override bind/port (default port = rest_port + 1)
+townhall mcp-http --bind 127.0.0.1 --port 8081
+```
+
+## Registered MCP Tools
+
+Read tools:
+
+- `town.get_status`
+- `agent.list`
+- `backlog.list`
+
+Write tools:
+
+- `task.assign`
+- `message.send`
+- `backlog.add`
+- `backlog.claim`
+- `backlog.assign_all`
+
+Agent-management/recovery tools:
+
+- `agent.spawn`
+- `agent.kill`
+- `agent.restart`
+- `recovery.recover_agents`
+- `recovery.reclaim_tasks`
+
+Tool responses are JSON payloads wrapped as:
+
+```json
+{
+  "success": true,
+  "data": {},
+  "error": null
+}
+```
+
+## Registered MCP Resources
+
+Static resources:
+
+- `tinytown://town/current`
+- `tinytown://agents`
+- `tinytown://backlog`
+
+Resource templates:
+
+- `tinytown://agents/{agent_name}`
+- `tinytown://tasks/{task_id}`
+
+## Registered MCP Prompts
+
+- `conductor.startup_context`
+- `agent.role_hint` (`agent_name` required, `tags` optional)
+
+## Notes
+
+- MCP tools call the same Tinytown service layer used by CLI and REST.
+- `mcp-http` uses Tower MCP's HTTP/SSE transport and follows standard MCP message semantics.

--- a/docs/src/advanced/townhall-rest.md
+++ b/docs/src/advanced/townhall-rest.md
@@ -1,0 +1,80 @@
+# Townhall REST API
+
+`townhall` is Tinytown's REST control plane daemon. It exposes the same orchestration services used by the `tt` CLI over HTTP.
+
+## Start the Server
+
+```bash
+# From a town directory
+townhall
+
+# Explicit REST mode
+townhall rest
+
+# Override bind/port
+townhall rest --bind 127.0.0.1 --port 8080
+```
+
+Defaults come from `tinytown.toml`:
+
+```toml
+[townhall]
+bind = "127.0.0.1"
+rest_port = 8080
+request_timeout_ms = 30000
+```
+
+## Endpoint Groups
+
+The router is split into public/read/write/management groups:
+
+- Public: `GET /healthz`
+- Read (`town.read`): `GET /v1/town`, `GET /v1/status`, `GET /v1/agents`, `GET /v1/tasks/pending`, `GET /v1/backlog`, `POST /v1/agents/{agent}/inbox`
+- Write (`town.write`): `POST /v1/tasks/assign`, `POST /v1/backlog`, `POST /v1/backlog/{task_id}/claim`, `POST /v1/backlog/assign-all`, `POST /v1/messages/send`
+- Agent management (`agent.manage`): `POST /v1/agents`, `POST /v1/agents/{agent}/kill`, `POST /v1/agents/{agent}/restart`, `POST /v1/agents/prune`, `POST /v1/recover`, `POST /v1/reclaim`
+
+## Authentication
+
+`townhall` supports three auth modes in config:
+
+- `none` (default): local/no-auth mode
+- `api_key`: API key via `Authorization: Bearer <key>` or `X-API-Key`
+- `oidc`: declared in config, not yet implemented in middleware
+
+Generate an API key + Argon2 hash:
+
+```bash
+tt auth gen-key
+```
+
+Then configure:
+
+```toml
+[townhall.auth]
+mode = "api_key"
+api_key_hash = "$argon2id$..."
+api_key_scopes = ["town.read", "town.write", "agent.manage"]
+```
+
+Example request:
+
+```bash
+curl -H "Authorization: Bearer $TOWNHALL_API_KEY" \
+  http://127.0.0.1:8080/v1/status
+```
+
+## Startup Safety Rules
+
+At startup, `townhall` fails fast when:
+
+- Binding to a non-loopback address with `auth.mode = "none"`
+- TLS is enabled but `cert_file`/`key_file` are missing or invalid
+- mTLS is required but `ca_file` is missing or invalid
+
+## OpenAPI Spec
+
+The REST contract is documented in:
+
+- `docs/openapi/townhall-v1.yaml`
+
+You can load this file in Swagger UI, Stoplight, or Redoc for interactive exploration.


### PR DESCRIPTION
## Summary
- add dedicated docs pages for the townhall REST API and MCP server
- wire the new pages into mdBook navigation and advanced API quick links
- add a programmatic interfaces section to the top-level README
- align OpenAPI with implementation by documenting /v1/agents/prune and updating default server URL to http://localhost:8080

## Validation
- mdbook build docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/OpenAPI-only and don’t affect runtime behavior, aside from potentially impacting external clients that consume the spec.
> 
> **Overview**
> Adds a new **Programmatic Interfaces** section to the top-level `README.md` and introduces dedicated mdBook pages for **`townhall` REST** and **MCP** usage, including startup commands, auth/config notes, and the exposed tool/resource surface.
> 
> Wires the new pages into docs navigation (`docs/src/SUMMARY.md`, `docs/src/README.md`, and `docs/src/advanced/api.md`) and updates `docs/openapi/townhall-v1.yaml` to use the `8080` default server URL and document the `POST /v1/agents/prune` endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f73b0a9354a2419cd9bec92d9a2f79b2f3762991. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->