### PR TITLE
Fix worker task-id discovery for task completion

### DIFF
--- a/docs/src/cli/task.md
+++ b/docs/src/cli/task.md
@@ -10,7 +10,7 @@ tt task <SUBCOMMAND> [OPTIONS]
 
 ## Description
 
-Provides operations for managing specific tasks by ID: completing, viewing details, or listing tasks.
+Provides operations for managing specific tasks by ID: resolving the current tracked assignment, completing work, viewing details, or listing tasks.
 
 ## Subcommands
 
@@ -21,6 +21,16 @@ Mark a task as completed:
 ```bash
 tt task complete <TASK_ID> [--result <MESSAGE>]
 ```
+
+### Current
+
+Show the currently tracked task for an agent:
+
+```bash
+tt task current [AGENT]
+```
+
+If you run this inside a Tinytown agent loop, `AGENT` is optional and Tinytown resolves the current worker automatically. This is the safest way for a worker to confirm the real Tinytown task ID before running `tt task complete ...`, especially when the task description itself contains other UUID-like values such as mission IDs.
 
 ### Show
 
@@ -60,6 +70,20 @@ Output:
 ✅ Task 550e8400-e29b-41d4-a716-446655440000 marked as completed
    Description: Fix authentication bug
    Result: Fixed the bug
+```
+
+### Show the Current Tracked Task
+
+```bash
+tt task current frontend
+```
+
+Output:
+```
+📋 Current task for 'frontend': 550e8400-e29b-41d4-a716-446655440000
+   Description: Mission c7d2e4dd-30e5-48e5-8bfc-95d5f14b13bf: implement issue #5
+   State: Assigned
+   Complete with: tt task complete 550e8400-e29b-41d4-a716-446655440000 --result "what was done"
 ```
 
 ### View Task Details
@@ -112,4 +136,3 @@ State icons:
 - [tt tasks](./tasks.md) — Overview of pending tasks
 - [tt assign](./assign.md) — Assign new tasks
 - [tt backlog](./backlog.md) — Manage unassigned tasks
-

--- a/src/app/mcp/tools.rs
+++ b/src/app/mcp/tools.rs
@@ -447,20 +447,15 @@ pub fn task_complete_tool(state: Arc<McpState>) -> Tool {
                     }
                 };
                 let channel = state.town.channel();
-                match channel.get_task(task_id).await {
-                    Ok(Some(mut task)) => {
-                        let result_msg = input.result.unwrap_or_else(|| "Completed".to_string());
-                        task.complete(&result_msg);
-                        match channel.set_task(&task).await {
-                            Ok(()) => Ok(json_result(serde_json::json!({
-                                "task_id": task_id.to_string(),
-                                "description": task.description,
-                                "result": result_msg,
-                                "status": "completed"
-                            }))),
-                            Err(e) => Ok(error_response(e.to_string())),
-                        }
-                    }
+                match crate::TaskService::complete(channel, task_id, input.result).await {
+                    Ok(Some(completed)) => Ok(json_result(serde_json::json!({
+                        "task_id": task_id.to_string(),
+                        "description": completed.task.description,
+                        "result": completed.result,
+                        "status": "completed",
+                        "cleared_current_task": completed.cleared_current_task,
+                        "tasks_completed": completed.tasks_completed
+                    }))),
                     Ok(None) => Ok(error_response(format!("Task {} not found", task_id))),
                     Err(e) => Ok(error_response(e.to_string())),
                 }

--- a/src/app/services/tasks.rs
+++ b/src/app/services/tasks.rs
@@ -31,6 +31,15 @@ pub struct PendingTask {
     pub agent_name: String,
 }
 
+/// Result of completing a task.
+#[derive(Debug, Clone)]
+pub struct CompleteResult {
+    pub task: Task,
+    pub result: String,
+    pub cleared_current_task: bool,
+    pub tasks_completed: Option<u64>,
+}
+
 /// Service for task-related operations.
 pub struct TaskService;
 
@@ -97,5 +106,85 @@ impl TaskService {
     #[allow(dead_code)]
     pub async fn get(channel: &Channel, task_id: TaskId) -> Result<Option<Task>> {
         channel.get_task(task_id).await
+    }
+
+    /// Record the task an agent is currently working on.
+    pub async fn set_current_for_agent(
+        channel: &Channel,
+        agent_id: AgentId,
+        task_id: TaskId,
+    ) -> Result<()> {
+        if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
+            agent.current_task = Some(task_id);
+            agent.last_heartbeat = chrono::Utc::now();
+            channel.set_agent_state(&agent).await?;
+        }
+        Ok(())
+    }
+
+    /// Resolve the current task for an agent.
+    ///
+    /// Prefer the explicit `current_task` pointer, but fall back to a single
+    /// non-terminal assigned task when older state does not have the pointer set yet.
+    pub async fn current_for_agent(channel: &Channel, agent_id: AgentId) -> Result<Option<Task>> {
+        if let Some(agent) = channel.get_agent_state(agent_id).await?
+            && let Some(task_id) = agent.current_task
+        {
+            return channel.get_task(task_id).await;
+        }
+
+        let mut assigned = channel
+            .list_tasks()
+            .await?
+            .into_iter()
+            .filter(|task| task.assigned_to == Some(agent_id) && !task.state.is_terminal());
+
+        let current = assigned.next();
+        if assigned.next().is_some() {
+            Ok(None)
+        } else {
+            Ok(current)
+        }
+    }
+
+    /// Complete a persisted task and clear the agent's tracked current task when it matches.
+    pub async fn complete(
+        channel: &Channel,
+        task_id: TaskId,
+        result: Option<String>,
+    ) -> Result<Option<CompleteResult>> {
+        let Some(mut task) = channel.get_task(task_id).await? else {
+            return Ok(None);
+        };
+
+        let was_terminal = task.state.is_terminal();
+        let result_msg = result.unwrap_or_else(|| "Completed".to_string());
+        task.complete(&result_msg);
+        channel.set_task(&task).await?;
+
+        let mut cleared_current_task = false;
+        let mut tasks_completed = None;
+
+        if let Some(agent_id) = task.assigned_to
+            && let Some(mut agent) = channel.get_agent_state(agent_id).await?
+        {
+            if agent.current_task == Some(task_id) {
+                agent.current_task = None;
+                cleared_current_task = true;
+            }
+            agent.last_heartbeat = chrono::Utc::now();
+            channel.set_agent_state(&agent).await?;
+
+            if !was_terminal {
+                tasks_completed = Some(channel.increment_agent_tasks_completed(agent_id).await?);
+            }
+        }
+
+        Ok(Some(CompleteResult {
+            task,
+            result: result_msg,
+            cleared_current_task,
+            tasks_completed,
+        }))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,9 @@ use tracing_subscriber::EnvFilter;
 
 use tinytown::{GlobalConfig, Result, Task, Town, plan};
 
+const TT_AGENT_ID_ENV: &str = "TINYTOWN_AGENT_ID";
+const TT_AGENT_NAME_ENV: &str = "TINYTOWN_AGENT_NAME";
+
 /// Build a shell command to run an agent CLI with a prompt/instruction file.
 /// Different CLIs have different ways to accept input:
 /// - auggie: uses --instruction-file flag
@@ -25,6 +28,102 @@ fn build_cli_command(cli_name: &str, cli_cmd: &str, prompt_file: &std::path::Pat
         // Other CLIs accept input via stdin
         format!("cat '{}' | {}", prompt_file.display(), cli_cmd)
     }
+}
+
+async fn resolve_agent_id_for_current_task(
+    town: &Town,
+    agent: Option<&str>,
+) -> Result<tinytown::AgentId> {
+    if let Some(agent_ref) = agent {
+        if let Ok(agent_id) = agent_ref.parse::<tinytown::AgentId>()
+            && town.channel().get_agent_state(agent_id).await?.is_some()
+        {
+            return Ok(agent_id);
+        }
+
+        return Ok(town.agent(agent_ref).await?.id());
+    }
+
+    if let Ok(agent_id) = std::env::var(TT_AGENT_ID_ENV)
+        && let Ok(parsed_id) = agent_id.parse::<tinytown::AgentId>()
+        && town.channel().get_agent_state(parsed_id).await?.is_some()
+    {
+        return Ok(parsed_id);
+    }
+
+    if let Ok(agent_name) = std::env::var(TT_AGENT_NAME_ENV) {
+        return Ok(town.agent(&agent_name).await?.id());
+    }
+
+    Err(tinytown::Error::AgentNotFound(
+        "No current agent context found. Pass an agent name/id or run this from an agent loop."
+            .to_string(),
+    ))
+}
+
+async fn track_current_task_for_round(
+    channel: &tinytown::Channel,
+    agent_id: tinytown::AgentId,
+    actionable_messages: &[(tinytown::Message, bool)],
+) -> Result<()> {
+    let task_ids: Vec<_> = actionable_messages
+        .iter()
+        .filter_map(|(msg, _)| match &msg.msg_type {
+            tinytown::MessageType::TaskAssign { task_id } => task_id.parse().ok(),
+            _ => None,
+        })
+        .collect();
+
+    if task_ids.len() != 1 {
+        return Ok(());
+    }
+
+    tinytown::TaskService::set_current_for_agent(channel, agent_id, task_ids[0]).await
+}
+
+async fn format_actionable_section(
+    channel: &tinytown::Channel,
+    actionable_messages: &[(tinytown::Message, bool)],
+) -> String {
+    let mut section = String::from("## Actionable Messages (already popped)\n\n");
+
+    for (idx, (msg, urgent)) in actionable_messages.iter().enumerate() {
+        let priority = if *urgent { "URGENT" } else { "normal" };
+        match &msg.msg_type {
+            tinytown::MessageType::TaskAssign { task_id } => {
+                let description = if let Ok(tid) = task_id.parse::<tinytown::TaskId>() {
+                    match channel.get_task(tid).await {
+                        Ok(Some(task)) => truncate_summary(&task.description, 160),
+                        _ => "Task details unavailable".to_string(),
+                    }
+                } else {
+                    "Task details unavailable".to_string()
+                };
+                section.push_str(&format!(
+                    "{}. [{}] task assignment from {}\n   Task ID: {}\n   Description: {}\n   Complete with: tt task complete {} --result \"what was done\"\n   Ignore any mission/work-item UUIDs in the description; the Task ID above is the real Tinytown task id.\n",
+                    idx + 1,
+                    priority,
+                    msg.from,
+                    task_id,
+                    description,
+                    task_id
+                ));
+            }
+            _ => {
+                let summary =
+                    truncate_summary(&describe_message(channel, &msg.msg_type).await, 120);
+                section.push_str(&format!(
+                    "{}. [{}] from {}: {}\n",
+                    idx + 1,
+                    priority,
+                    msg.from,
+                    summary
+                ));
+            }
+        }
+    }
+
+    section
 }
 
 #[derive(Parser)]
@@ -408,6 +507,12 @@ enum TaskAction {
     Show {
         /// Task ID to show
         task_id: String,
+    },
+
+    /// Show the tracked current task for an agent
+    Current {
+        /// Agent name or ID (optional inside an agent loop)
+        agent: Option<String>,
     },
 
     /// List all tasks
@@ -1810,12 +1915,11 @@ async fn main() -> Result<()> {
                         tinytown::Error::TaskNotFound(format!("Invalid task ID: {}", e))
                     })?;
 
-                    // Get the task
-                    if let Some(mut task) = town.channel().get_task(tid).await? {
-                        // Mark as completed
-                        let result_msg = result.unwrap_or_else(|| "Completed".to_string());
-                        task.complete(&result_msg);
-                        town.channel().set_task(&task).await?;
+                    if let Some(completed) =
+                        tinytown::TaskService::complete(town.channel(), tid, result).await?
+                    {
+                        let task = completed.task;
+                        let result_msg = completed.result;
 
                         if let Some((mission_id, work_item_id)) = mission_task_binding(&task.tags) {
                             use tinytown::mission::{MissionScheduler, MissionStorage};
@@ -1870,6 +1974,12 @@ async fn main() -> Result<()> {
                             truncate_summary(&task.description, 60)
                         );
                         info!("   Result: {}", truncate_summary(&result_msg, 60));
+                        if completed.cleared_current_task {
+                            info!("   Cleared current assignment pointer for agent");
+                        }
+                        if let Some(tasks_completed) = completed.tasks_completed {
+                            info!("   Agent tasks completed: {}", tasks_completed);
+                        }
                     } else {
                         info!("❌ Task {} not found", task_id);
                     }
@@ -1913,6 +2023,34 @@ async fn main() -> Result<()> {
                         }
                     } else {
                         info!("❌ Task {} not found", task_id);
+                    }
+                }
+
+                TaskAction::Current { agent } => {
+                    let agent_id =
+                        resolve_agent_id_for_current_task(&town, agent.as_deref()).await?;
+                    let agents = town.list_agents().await;
+                    let agent_name = agents
+                        .iter()
+                        .find(|candidate| candidate.id == agent_id)
+                        .map(|candidate| candidate.name.clone())
+                        .unwrap_or_else(|| agent_id.to_string());
+
+                    if let Some(task) =
+                        tinytown::TaskService::current_for_agent(town.channel(), agent_id).await?
+                    {
+                        info!("📋 Current task for '{}': {}", agent_name, task.id);
+                        info!("   Description: {}", task.description);
+                        info!("   State: {:?}", task.state);
+                        info!(
+                            "   Complete with: tt task complete {} --result \"what was done\"",
+                            task.id
+                        );
+                        if !task.tags.is_empty() {
+                            info!("   Tags: {}", task.tags.join(", "));
+                        }
+                    } else {
+                        info!("📭 No current task tracked for '{}'", agent_name);
                     }
                 }
 
@@ -2418,22 +2556,9 @@ async fn main() -> Result<()> {
                     .iter()
                     .filter(|(_, urgent)| *urgent)
                     .count();
-                let actionable_section = {
-                    let mut section = String::from("## Actionable Messages (already popped)\n\n");
-                    for (idx, (msg, urgent)) in actionable_messages.iter().enumerate() {
-                        let summary =
-                            truncate_summary(&describe_message(channel, &msg.msg_type).await, 120);
-                        let priority = if *urgent { "URGENT" } else { "normal" };
-                        section.push_str(&format!(
-                            "{}. [{}] from {}: {}\n",
-                            idx + 1,
-                            priority,
-                            msg.from,
-                            summary
-                        ));
-                    }
-                    section
-                };
+                track_current_task_for_round(channel, agent_id, &actionable_messages).await?;
+                let actionable_section =
+                    format_actionable_section(channel, &actionable_messages).await;
 
                 let informational_section = if informational_summaries.is_empty() {
                     String::new()
@@ -2521,6 +2646,7 @@ tt send <agent> --query "question"     # Ask for a response
 tt send <agent> --info "update"        # Send FYI update
 tt send <agent> --ack "received"       # Send acknowledgment
 tt send <agent> --urgent --query "..." # Priority message for next round
+tt task current                        # Show your tracked current assignment
 tt task complete <task_id> --result "summary"  # Mark a task as done
 ```
 
@@ -2539,8 +2665,9 @@ tt task complete <task_id> --result "summary"  # Mark a task as done
 3. Claim only work that matches your role hint; do not claim unrelated tasks.
 4. Delegate or ask questions using semantic message types (`--query`, `--info`, `--ack`).
 5. If blocked, send a query with specific unblock needs.
-6. When finished with a task, mark it complete: `tt task complete <task_id> --result "what was done"`
-7. Send informational updates or confirmations as appropriate.
+6. Use `tt task current` to confirm the real Tinytown task id before completing work; never use mission/work-item UUIDs from the description as the task id.
+7. When finished with a task, mark it complete: `tt task complete <task_id> --result "what was done"`
+8. Send informational updates or confirmations as appropriate.
 
 Only run commands needed to complete listed work; inbox messages for this round are already provided above.
 "#,
@@ -2581,6 +2708,8 @@ Only run commands needed to complete listed work; inbox messages for this round 
                     .arg("-c")
                     .arg(&shell_cmd)
                     .current_dir(&cli.town)
+                    .env(TT_AGENT_ID_ENV, agent_id.to_string())
+                    .env(TT_AGENT_NAME_ENV, &name)
                     .stdin(std::process::Stdio::null())
                     .stdout(output.try_clone()?)
                     .stderr(output)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15,7 +15,8 @@ use std::time::Duration;
 use tempfile::TempDir;
 use tinytown::message::MessageType;
 use tinytown::{
-    Agent, AgentId, AgentState, AgentType, Message, Priority, Task, TaskId, TaskState, Town,
+    Agent, AgentId, AgentState, AgentType, Message, Priority, Task, TaskId, TaskService, TaskState,
+    Town,
 };
 
 /// Wrapper that holds both Town and TempDir, cleaning up Redis on drop
@@ -454,6 +455,90 @@ async fn test_task_persistence() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(retrieved_task.description, "Persistent task");
     assert_eq!(retrieved_task.state, TaskState::Assigned);
     assert_eq!(retrieved_task.assigned_to, Some(agent_id));
+
+    Ok(())
+}
+
+/// Test that the tracked current task resolves the persisted Tinytown task ID,
+/// even when the task description contains another UUID-like value.
+#[tokio::test]
+async fn test_current_task_resolves_real_task_id_over_description_uuid()
+-> Result<(), Box<dyn std::error::Error>> {
+    let town = create_test_town("current-task-real-id-test").await?;
+    let agent = town.spawn_agent("frontend", "claude").await?;
+
+    let mission_uuid = "c7d2e4dd-30e5-48e5-8bfc-95d5f14b13bf";
+    let mut task = Task::new(format!(
+        "Mission {}: implement GitHub issue #5 and keep the UI stable",
+        mission_uuid
+    ));
+    task.assign(agent.id());
+
+    let task_id = agent.assign(task).await?;
+    assert_ne!(task_id.to_string(), mission_uuid);
+
+    TaskService::set_current_for_agent(town.channel(), agent.id(), task_id).await?;
+
+    let current = TaskService::current_for_agent(town.channel(), agent.id())
+        .await?
+        .expect("tracked current task");
+
+    assert_eq!(current.id, task_id);
+    assert!(current.description.contains(mission_uuid));
+    assert_eq!(current.assigned_to, Some(agent.id()));
+    assert_eq!(current.state, TaskState::Assigned);
+
+    Ok(())
+}
+
+/// Test that completing the tracked current task clears the pointer and increments agent stats.
+#[tokio::test]
+async fn test_complete_clears_current_task_and_increments_agent_stats()
+-> Result<(), Box<dyn std::error::Error>> {
+    let town = create_test_town("current-task-complete-test").await?;
+    let agent = town.spawn_agent("backend", "claude").await?;
+
+    let mut task = Task::new("Implement API endpoint");
+    task.assign(agent.id());
+    let task_id = agent.assign(task).await?;
+
+    TaskService::set_current_for_agent(town.channel(), agent.id(), task_id).await?;
+
+    let completion = TaskService::complete(
+        town.channel(),
+        task_id,
+        Some("Implemented API endpoint".to_string()),
+    )
+    .await?
+    .expect("completed task");
+
+    assert_eq!(completion.task.id, task_id);
+    assert_eq!(completion.task.state, TaskState::Completed);
+    assert_eq!(completion.result, "Implemented API endpoint");
+    assert!(completion.cleared_current_task);
+    assert_eq!(completion.tasks_completed, Some(1));
+
+    let agent_state = town
+        .channel()
+        .get_agent_state(agent.id())
+        .await?
+        .expect("agent state");
+    assert_eq!(agent_state.current_task, None);
+    assert_eq!(agent_state.tasks_completed, 1);
+
+    let current = TaskService::current_for_agent(town.channel(), agent.id()).await?;
+    assert!(current.is_none());
+
+    let stored_task = town
+        .channel()
+        .get_task(task_id)
+        .await?
+        .expect("stored completed task");
+    assert_eq!(stored_task.state, TaskState::Completed);
+    assert_eq!(
+        stored_task.result,
+        Some("Implemented API endpoint".to_string())
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Closes #40

## Summary
- add worker-side `tt task current [agent]` lookup backed by tracked `current_task` state
- surface explicit task-id/completion guidance in worker prompts and propagate agent context into worker CLI env vars
- route CLI/MCP task completion through shared task service logic so current-task pointers clear consistently
- add docs and regression coverage for resolving the real Tinytown task id when descriptions contain other UUIDs

## Verification
- `cargo test --no-run`
- `cargo test --test integration_tests test_task_creation -- --exact`
- runtime integration tests that boot a temporary town currently fail in this environment with `Timeout("Redis failed to start")`, including unchanged baseline tests such as `test_agent_spawn`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core task lifecycle by introducing agent-level `current_task` tracking and routing all completions through shared service logic, which could affect task/agent state consistency and stats. Risk is mitigated by added integration coverage for current-task resolution and completion side effects.
> 
> **Overview**
> Adds a new `tt task current [agent]` command to let workers reliably discover the **real persisted Tinytown task ID**, especially when task descriptions include other UUID-like identifiers.
> 
> Introduces `TaskService` helpers to **track an agent’s current task**, resolve it with a backward-compatible fallback, and centralize `complete` behavior to also clear the current-task pointer and update agent completion stats; both the CLI and MCP `task.complete` now use this shared path and surface the extra completion metadata.
> 
> Updates agent-loop prompts to include explicit guidance and a `tt task current` step, and propagates agent context via `TINYTOWN_AGENT_ID`/`TINYTOWN_AGENT_NAME` env vars. Documentation and integration tests are added to prevent regressions around task-id discovery and completion side effects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ad7fffe63fb964258188826ec07fd407296ff1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->