### PR TITLE
Clarify conductor report-back loop

### DIFF
--- a/docs/src/cli/conductor.md
+++ b/docs/src/cli/conductor.md
@@ -161,6 +161,41 @@ When the next execution handoff is obvious, prefer direct agent-to-agent messagi
 
 Keep the conductor in the loop with `tt send supervisor --info ...` when a human should stay informed, but do not force routine execution routing through the conductor.
 
+## How Workers Report Back
+
+Use `conductor` as the user-facing name for the human-in-the-loop orchestrator. `supervisor` is the same well-known mailbox internally, so the names are interchangeable in CLI commands.
+
+Recommended loop:
+
+```bash
+# Worker reports progress, completion, or FYI context
+tt send supervisor --info "Implementation complete; reviewer should inspect src/auth.rs"
+
+# Worker is blocked and needs a human decision
+tt send conductor --query "Need a decision on password reset token lifetime"
+
+# Worker only needs to confirm receipt
+tt send supervisor --ack "Received. I will start after current task."
+
+# Conductor reads report-backs
+tt inbox conductor
+tt inbox --all
+tt status --deep
+```
+
+Use each message type intentionally:
+- `--info` for progress updates, completion notices, or context the conductor should see
+- `--query` for blockers, ambiguity, or decisions that need a response
+- `--ack` for simple receipt/confirmation only
+
+When a worker finishes a real Tinytown task, they should still use:
+
+```bash
+tt task complete <task_id> --result "what changed"
+```
+
+Treat the `tt send ...` report-back as coordination, not as a substitute for task completion.
+
 ## The Conductor's Context
 
 The conductor receives a markdown context file that includes:

--- a/docs/src/cli/send.md
+++ b/docs/src/cli/send.md
@@ -12,6 +12,8 @@ tt send <TO> <MESSAGE> [OPTIONS]
 
 Sends a semantic message to an agent's inbox. The agent will receive it on their next inbox check.
 
+`conductor` and `supervisor` are interchangeable names for the same well-known conductor mailbox, so either target works when agents need to report back to the human orchestrator.
+
 Message semantics:
 - Default (no semantic flag): Task-style/actionable message
 - `--query`: Question that expects a response or decision
@@ -72,6 +74,25 @@ tt send reviewer --info "CI is green on commit a1b2c3d"
 ```bash
 tt send conductor --ack "Received. I'll start after current task."
 ```
+
+### Report Back to the Conductor
+
+```bash
+# Progress or completion notice
+tt send supervisor --info "Implementation complete; ready for review"
+
+# Blocked, needs a human decision
+tt send conductor --query "Need a decision on OAuth scope naming"
+
+# Simple receipt only
+tt send supervisor --ack "Received. I will start after current task."
+```
+
+Recommended pattern:
+- Use `--info` for progress updates, completion notices, or FYI visibility
+- Use `--query` when blocked or when human judgment is needed
+- Use `--ack` only for receipt/confirmation
+- If the work corresponds to a real Tinytown task, still run `tt task complete <task_id> --result "summary"` when it is actually done
 
 ### Send an URGENT Message
 

--- a/docs/src/concepts/coordination.md
+++ b/docs/src/concepts/coordination.md
@@ -110,6 +110,20 @@ Use `supervisor` / `conductor` when you need:
 - escalation or blockers
 - visibility for the broader town
 
+`conductor` is the user-facing name for that human-in-the-loop role. `supervisor` is the same well-known mailbox internally, so either name works in CLI commands.
+
+A practical report-back loop looks like:
+
+```bash
+tt send supervisor --info "Implementation complete; reviewer should take a look"
+tt send conductor --query "Need a decision on rollout timing"
+tt inbox conductor
+tt inbox --all
+tt status --deep
+```
+
+Use those messages for coordination, and still use `tt task complete <task_id> --result "summary"` when a real Tinytown task is actually finished.
+
 ## Keeping It Simple
 
 Tinytown deliberately avoids:

--- a/src/main.rs
+++ b/src/main.rs
@@ -3150,6 +3150,19 @@ tt send <agent> --urgent --query "msg" # URGENT: processed first next round
 tt inbox <agent>                   # Check agent's inbox
 ```
 
+### Worker Report-Back Loop
+
+- `conductor` is the user-facing role name; `supervisor` is the same well-known mailbox/id.
+- Workers should report back to the conductor with:
+  - `tt send supervisor --info "implementation complete; reviewer should look at src/auth.rs"`
+  - `tt send conductor --query "Need product decision on password reset behavior"`
+  - `tt send supervisor --ack "Received. I will start after current task."`
+- Conductor should monitor those report-backs with:
+  - `tt inbox conductor`
+  - `tt inbox --all`
+  - `tt status --deep`
+- When work tied to a real Tinytown task is done, workers should still run `tt task complete <task_id> --result "what changed"` instead of only sending an informational message.
+
 ### Check status and stats
 ```bash
 tt status         # Overview of town and agents


### PR DESCRIPTION
## Summary
- clarify that `conductor` is the user-facing name and `supervisor` is the same well-known mailbox
- document the recommended worker report-back loop, including how the conductor reads those messages
- spell out when to use `--info`, `--query`, `--ack`, and when to use `tt task complete`

Closes #36.

## Verification
- `cargo fmt`
- `cargo check`
- `cargo test --bin tt`
- `cargo clippy --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation and in-app help text clarifying messaging conventions, with no behavior or data-path modifications.
> 
> **Overview**
> Clarifies that `conductor` is the user-facing name and `supervisor` is the same well-known mailbox, and documents a recommended worker report-back loop.
> 
> Adds concrete CLI examples for when to use `tt send --info`/`--query`/`--ack`, how the conductor monitors via `tt inbox`/`tt status --deep`, and reiterates that real work completion should still use `tt task complete` (updated in `tt conductor` docs, `tt send` docs, and the conductor context in `src/main.rs`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6565a124b2d48ed318039064906ea0dd7b2657d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->