### PR TITLE
[codex] Fix mission resume watch override

### DIFF
--- a/src/mission/dispatcher.rs
+++ b/src/mission/dispatcher.rs
@@ -20,7 +20,7 @@ use crate::error::Result;
 use crate::message::{Message, MessageType};
 use crate::mission::scheduler::{MissionScheduler, SchedulerTickResult};
 use crate::mission::storage::MissionStorage;
-use crate::mission::types::{MissionId, MissionState};
+use crate::mission::types::{MissionId, MissionState, WatchStatus};
 use crate::mission::watch::{GitHubClient, WatchEngine, WatchEngineTickResult};
 
 /// Dispatcher configuration.
@@ -218,6 +218,7 @@ impl<G: GitHubClient> MissionDispatcher<G> {
             let body = message.body.trim();
             let lower = body.to_ascii_lowercase();
             if lower.starts_with("resume") || lower.starts_with("retry") {
+                let completed_watches = self.force_complete_blocking_watches(mission_id).await?;
                 mission.start();
                 mission.set_next_wake_at(None);
                 progressed = true;
@@ -225,8 +226,17 @@ impl<G: GitHubClient> MissionDispatcher<G> {
                     .log_event(
                         mission_id,
                         &format!(
-                            "Dispatcher received resume directive from {}: {}",
-                            message.sender, body
+                            "Dispatcher received resume directive from {}: {}{}",
+                            message.sender,
+                            body,
+                            if completed_watches > 0 {
+                                format!(
+                                    " (force-completed {} blocking watch(es))",
+                                    completed_watches
+                                )
+                            } else {
+                                String::new()
+                            }
                         ),
                     )
                     .await?;
@@ -260,6 +270,23 @@ impl<G: GitHubClient> MissionDispatcher<G> {
 
         self.storage.save_mission(&mission).await?;
         Ok(progressed)
+    }
+
+    async fn force_complete_blocking_watches(&self, mission_id: MissionId) -> Result<usize> {
+        let watches = self.storage.list_watch_items(mission_id).await?;
+        let mut completed = 0;
+
+        for mut watch in watches {
+            if watch.status == WatchStatus::Done {
+                continue;
+            }
+
+            watch.complete();
+            self.storage.save_watch_item(&watch).await?;
+            completed += 1;
+        }
+
+        Ok(completed)
     }
 
     async fn assess_help_needed(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3708,6 +3708,73 @@ async fn test_mission_dispatcher_processes_conductor_note() -> Result<(), Box<dy
     Ok(())
 }
 
+/// Test that a resume directive force-completes blocking watches so work can finalize.
+#[tokio::test]
+async fn test_mission_dispatcher_resume_note_completes_blocking_watches()
+-> Result<(), Box<dyn std::error::Error>> {
+    use tinytown::mission::{
+        DispatcherConfig, MissionControlMessage, MissionDispatcher, MissionRun, MissionState,
+        MissionStorage, MockGitHubClient, ObjectiveRef, TriggerAction, WatchItem, WatchKind,
+        WatchStatus, WorkItem, WorkKind, WorkStatus,
+    };
+
+    let temp_dir = TempDir::new()?;
+    let town_name = unique_town_name("mission-dispatch-resume-watches");
+    let town = Town::init(temp_dir.path(), &town_name).await?;
+    let storage = MissionStorage::new(town.channel().conn().clone(), &town_name);
+
+    let mut mission = MissionRun::new(vec![ObjectiveRef::Doc {
+        path: "test.md".into(),
+    }]);
+    mission.policy.reviewer_required = false;
+    mission.block("Waiting on external watch");
+    storage.save_mission(&mission).await?;
+    storage.add_active(mission.id).await?;
+
+    let mut item = WorkItem::new(mission.id, "Implement auth", WorkKind::Implement);
+    item.block();
+    item.record_artifacts(["test/repo#21"]);
+    storage.save_work_item(&item).await?;
+
+    let watch = WatchItem::new(
+        mission.id,
+        item.id,
+        WatchKind::PrChecks,
+        "test/repo#21",
+        3600,
+    )
+    .with_trigger(TriggerAction::AdvancePipeline);
+    storage.save_watch_item(&watch).await?;
+
+    let note = MissionControlMessage::new(mission.id, "conductor", "resume and finish now");
+    storage.save_control_message(&note).await?;
+
+    let dispatcher = MissionDispatcher::new(
+        storage.clone(),
+        town.channel().clone(),
+        MockGitHubClient::new(),
+        DispatcherConfig {
+            tick_interval_secs: 1,
+            lock_ttl_secs: 30,
+        },
+    );
+    dispatcher.tick(Some(mission.id)).await?;
+
+    let updated_watch = storage.get_watch_item(mission.id, watch.id).await?.unwrap();
+    assert_eq!(updated_watch.status, WatchStatus::Done);
+
+    let updated_item = storage.get_work_item(mission.id, item.id).await?.unwrap();
+    assert_eq!(updated_item.status, WorkStatus::Done);
+
+    let updated_mission = storage.get_mission(mission.id).await?.unwrap();
+    assert_eq!(updated_mission.state, MissionState::Completed);
+    assert!(updated_mission.blocked_reason.is_none());
+
+    drop(town);
+    cleanup_redis(&temp_dir);
+    Ok(())
+}
+
 // ============================================================================
 // DOCKET STREAM (REDIS STREAMS) TESTS
 // ============================================================================


### PR DESCRIPTION
## Summary
Fix the mission dispatcher so a conductor `resume` or `retry` note can authoritatively unblock a mission that is waiting on watches.

## What Changed
- force-complete any non-done watch items when processing a `resume`/`retry` control note
- include the forced-watch count in the dispatcher event log for operator visibility
- add a regression test covering blocked work + watch completion + mission completion on resume

## Root Cause
The dispatcher recognized `resume` notes, but it only moved the mission back to `Running`. Blocking watch items were left active, so the scheduler still saw the work item as blocked and the mission stayed stuck.

## Validation
- `cargo fmt --all`
- `cargo test test_mission_dispatcher_ -- --nocapture`

Fixes #71.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mission control semantics so `resume`/`retry` can override pending watches, which could prematurely complete watch-gated work if misused, but is limited to explicit operator directives and covered by a regression test.
> 
> **Overview**
> Makes conductor `resume`/`retry` notes *authoritatively unblock* missions by force-completing any non-`Done` watch items before restarting the mission, and logs how many watches were overridden for operator visibility.
> 
> Adds an integration regression test that sets up a blocked mission + blocked work item + active watch, then verifies a `resume` note completes the watch, finalizes the work item, and allows the mission to reach `Completed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d08d5db45e62dd2a887fa787a81d954c0ff5c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->