### PR TITLE
[codex] Add scale-to-zero worker signals

### DIFF
--- a/docs/openapi/townhall-v1.yaml
+++ b/docs/openapi/townhall-v1.yaml
@@ -142,6 +142,74 @@ paths:
               schema:
                 type: string
 
+  /api/scaling:
+    get:
+      tags: [Health]
+      summary: Autoscaler scaling signal
+      operationId: scalingSignal
+      responses:
+        '200':
+          description: JSON scaling snapshot for external autoscalers
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - town
+                  - timestamp
+                  - queue_depth
+                  - pending_tasks
+                  - in_flight_tasks
+                  - active_agents
+                  - cold_agents
+                  - desired_agents
+                  - max_agents
+                  - scaling_recommendation
+                properties:
+                  town:
+                    type: string
+                    example: mytown
+                  timestamp:
+                    type: string
+                    format: date-time
+                  queue_depth:
+                    type: integer
+                    minimum: 0
+                    example: 3
+                  pending_tasks:
+                    type: integer
+                    minimum: 0
+                    example: 2
+                  in_flight_tasks:
+                    type: integer
+                    minimum: 0
+                    example: 1
+                  active_agents:
+                    type: integer
+                    minimum: 0
+                    example: 1
+                  cold_agents:
+                    type: integer
+                    minimum: 0
+                    example: 0
+                  desired_agents:
+                    type: integer
+                    minimum: 0
+                    example: 3
+                  max_agents:
+                    type: integer
+                    minimum: 1
+                    example: 10
+                  scaling_recommendation:
+                    type: string
+                    enum: [scale_up, steady, scale_down, scale_to_zero]
+        '503':
+          description: Scaling signal unavailable because backing services are unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+
   /v1/town:
     get:
       tags: [Town]

--- a/docs/src/advanced/townhall-rest.md
+++ b/docs/src/advanced/townhall-rest.md
@@ -77,7 +77,7 @@ idle_timeout_secs = 300
 
 When the timeout expires, the worker transitions `Idle -> Draining -> Stopped` and exits cleanly with status code `0`. That gives an external autoscaler a stable signal for both scale-down and full scale-to-zero.
 
-When `use_streams = true`, the scaling endpoint reports `queue_depth` from docket stream depth (`XLEN`), with `pending_tasks` excluding entries already claimed by consumers (`XPENDING`) and `in_flight_tasks` reporting the claimed subset.
+When `use_streams = true`, the scaling endpoint reports `pending_tasks` from the consumer-group unread lag, `in_flight_tasks` from `XPENDING`, and `queue_depth` as the sum of unread plus in-flight work. This avoids counting acknowledged stream entries that are retained for audit/history.
 
 ## Autoscaler Integration
 

--- a/docs/src/advanced/townhall-rest.md
+++ b/docs/src/advanced/townhall-rest.md
@@ -77,7 +77,7 @@ idle_timeout_secs = 300
 
 When the timeout expires, the worker transitions `Idle -> Draining -> Stopped` and exits cleanly with status code `0`. That gives an external autoscaler a stable signal for both scale-down and full scale-to-zero.
 
-When `use_streams = true`, the scaling endpoint uses docket stream depth (`XLEN`) plus pending consumer-group entries (`XPENDING`) so autoscalers can react to Redis Stream-backed work queues.
+When `use_streams = true`, the scaling endpoint reports `queue_depth` from docket stream depth (`XLEN`), with `pending_tasks` excluding entries already claimed by consumers (`XPENDING`) and `in_flight_tasks` reporting the claimed subset.
 
 ## Autoscaler Integration
 

--- a/docs/src/advanced/townhall-rest.md
+++ b/docs/src/advanced/townhall-rest.md
@@ -28,7 +28,7 @@ request_timeout_ms = 30000
 
 The router is split into public/read/write/management groups:
 
-- Public: `GET /health`, `GET /ready`, `GET /metrics`
+- Public: `GET /health`, `GET /ready`, `GET /metrics`, `GET /api/scaling`
 - Read (`town.read`): `GET /v1/town`, `GET /v1/status`, `GET /v1/agents`, `GET /v1/tasks/pending`, `GET /v1/backlog`, `GET /v1/agents/{agent}/inbox`
 - Write (`town.write`): `POST /v1/tasks/assign`, `POST /v1/backlog`, `POST /v1/backlog/{task_id}/claim`, `POST /v1/backlog/assign-all`, `DELETE /v1/backlog/{task_id}`, `POST /v1/messages/send`
 - Agent management (`agent.manage`): `POST /v1/agents`, `POST /v1/agents/{agent}/kill`, `POST /v1/agents/{agent}/restart`, `POST /v1/agents/prune`, `POST /v1/recover`, `POST /v1/reclaim`
@@ -38,8 +38,81 @@ The public probes have distinct purposes:
 - `/health`: lightweight process liveness with `uptime_secs`
 - `/ready`: verifies townhall can still reach Redis, reporting Redis latency, town name, and dispatcher heartbeat state
 - `/metrics`: Prometheus-style text metrics for agent counts by state, task queue depth, completed tasks, active missions, and Redis latency
+- `/api/scaling`: JSON scaling signal for autoscalers, including queue depth, in-flight work, desired worker count, and a scaling recommendation
 
 Compatibility aliases `/healthz` and `/readyz` remain available for existing deployments.
+
+## Scaling Signal API
+
+`GET /api/scaling` exposes an autoscaler-friendly snapshot:
+
+```json
+{
+  "town": "mytown",
+  "timestamp": "2026-04-04T18:00:00Z",
+  "queue_depth": 3,
+  "pending_tasks": 2,
+  "in_flight_tasks": 1,
+  "active_agents": 1,
+  "cold_agents": 0,
+  "desired_agents": 3,
+  "max_agents": 10,
+  "scaling_recommendation": "scale_up"
+}
+```
+
+`scaling_recommendation` values:
+
+- `scale_up`: pending + in-flight work exceeds current active workers
+- `steady`: current active workers match demand
+- `scale_down`: extra workers are running and there is no queued work
+- `scale_to_zero`: no queued work, no in-flight work, and all active workers have been idle past the configured timeout
+
+The worker idle timeout is configured in `tinytown.toml`:
+
+```toml
+[agent]
+idle_timeout_secs = 300
+```
+
+When the timeout expires, the worker transitions `Idle -> Draining -> Stopped` and exits cleanly with status code `0`. That gives an external autoscaler a stable signal for both scale-down and full scale-to-zero.
+
+When `use_streams = true`, the scaling endpoint uses docket stream depth (`XLEN`) plus pending consumer-group entries (`XPENDING`) so autoscalers can react to Redis Stream-backed work queues.
+
+## Autoscaler Integration
+
+Cloud Run:
+
+- Set `min-instances=0`
+- Poll `/api/scaling`
+- Use `desired_agents` or `queue_depth` to drive instance count
+
+KEDA:
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: tinytown-agents
+spec:
+  scaleTargetRef:
+    name: tinytown-agent-worker
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  triggers:
+    - type: metrics-api
+      metadata:
+        url: "http://townhall:8080/api/scaling"
+        valueLocation: "queue_depth"
+        targetValue: "1"
+```
+
+Custom scaler:
+
+- Poll `/api/scaling` on a short interval
+- Start workers when `scaling_recommendation` is `scale_up`
+- Remove workers when `scaling_recommendation` is `scale_down` or `scale_to_zero`
+- Prefer `desired_agents` as the authoritative target replica count
 
 ## Authentication
 

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -479,10 +479,11 @@ async fn gather_queue_depth(state: &AppState) -> std::result::Result<QueueDepthS
             Err(e) if e.to_string().contains("NOGROUP") => 0,
             Err(e) => return Err(format!("Failed to read docket pending count: {}", e)),
         };
+        let pending_tasks = stream_len.saturating_sub(pending_entries);
 
         return Ok(QueueDepthSnapshot {
-            queue_depth: stream_len + pending_entries,
-            pending_tasks: stream_len,
+            queue_depth: stream_len,
+            pending_tasks,
             in_flight_tasks: pending_entries,
         });
     }
@@ -500,7 +501,7 @@ async fn gather_queue_depth(state: &AppState) -> std::result::Result<QueueDepthS
     let in_flight_tasks = count_in_flight_tasks(&state.town).await?;
 
     Ok(QueueDepthSnapshot {
-        queue_depth: backlog_count + pending_task_count,
+        queue_depth: backlog_count + pending_task_count + in_flight_tasks,
         pending_tasks: backlog_count + pending_task_count,
         in_flight_tasks,
     })

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -468,22 +468,29 @@ async fn gather_scaling_signal(
 
 async fn gather_queue_depth(state: &AppState) -> std::result::Result<QueueDepthSnapshot, String> {
     if state.town.config().use_streams {
-        let stream_len = state
-            .town
-            .channel()
-            .docket_len()
-            .await
-            .map_err(|e| format!("Failed to read docket length: {}", e))?;
         let pending_entries = match state.town.channel().docket_pending_count().await {
             Ok(count) => count,
             Err(e) if e.to_string().contains("NOGROUP") => 0,
             Err(e) => return Err(format!("Failed to read docket pending count: {}", e)),
         };
-        let pending_tasks = stream_len.saturating_sub(pending_entries);
+        let unread_entries = match state.town.channel().docket_group_lag().await {
+            Ok(count) => count,
+            Err(e)
+                if e.to_string().contains("NOGROUP") || e.to_string().contains("no such key") =>
+            {
+                state
+                    .town
+                    .channel()
+                    .docket_len()
+                    .await
+                    .map_err(|err| format!("Failed to read docket length: {}", err))?
+            }
+            Err(e) => return Err(format!("Failed to read docket group lag: {}", e)),
+        };
 
         return Ok(QueueDepthSnapshot {
-            queue_depth: stream_len,
-            pending_tasks,
+            queue_depth: unread_entries + pending_entries,
+            pending_tasks: unread_entries,
             in_flight_tasks: pending_entries,
         });
     }

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -8,7 +8,7 @@
 //! This module provides the shared server infrastructure for the townhall daemon,
 //! making it accessible for integration testing.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
@@ -108,6 +108,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/healthz", get(health))
         .route("/ready", get(readiness))
         .route("/readyz", get(readiness))
+        .route("/api/scaling", get(scaling_signal))
         .route("/metrics", get(metrics));
 
     // Read-only routes (town.read scope)
@@ -202,6 +203,25 @@ async fn metrics(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     )
 }
 
+async fn scaling_signal(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    match gather_scaling_signal(&state).await {
+        Ok(snapshot) => (
+            StatusCode::OK,
+            Json(ScalingSignalResponse::from_snapshot(&snapshot)),
+        )
+            .into_response(),
+        Err(detail) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ProblemDetails::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Service Unavailable",
+                &detail,
+            )),
+        )
+            .into_response(),
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct HealthResponse {
     status: &'static str,
@@ -249,6 +269,67 @@ struct ReadinessSnapshot {
     town_name: String,
     redis_latency_secs: f64,
     dispatcher_status: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ScalingRecommendation {
+    ScaleUp,
+    Steady,
+    ScaleDown,
+    ScaleToZero,
+}
+
+#[derive(Debug)]
+struct ScalingSignalSnapshot {
+    town_name: String,
+    timestamp: chrono::DateTime<chrono::Utc>,
+    queue_depth: usize,
+    pending_tasks: usize,
+    in_flight_tasks: usize,
+    active_agents: usize,
+    cold_agents: usize,
+    desired_agents: usize,
+    max_agents: usize,
+    recommendation: ScalingRecommendation,
+}
+
+#[derive(Debug, Serialize)]
+struct ScalingSignalResponse {
+    town: String,
+    timestamp: String,
+    queue_depth: usize,
+    pending_tasks: usize,
+    in_flight_tasks: usize,
+    active_agents: usize,
+    cold_agents: usize,
+    desired_agents: usize,
+    max_agents: usize,
+    scaling_recommendation: ScalingRecommendation,
+}
+
+impl ScalingSignalResponse {
+    fn from_snapshot(snapshot: &ScalingSignalSnapshot) -> Self {
+        Self {
+            town: snapshot.town_name.clone(),
+            timestamp: snapshot.timestamp.to_rfc3339(),
+            queue_depth: snapshot.queue_depth,
+            pending_tasks: snapshot.pending_tasks,
+            in_flight_tasks: snapshot.in_flight_tasks,
+            active_agents: snapshot.active_agents,
+            cold_agents: snapshot.cold_agents,
+            desired_agents: snapshot.desired_agents,
+            max_agents: snapshot.max_agents,
+            scaling_recommendation: snapshot.recommendation,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct QueueDepthSnapshot {
+    queue_depth: usize,
+    pending_tasks: usize,
+    in_flight_tasks: usize,
 }
 
 #[derive(Debug)]
@@ -346,6 +427,145 @@ async fn gather_metrics(state: &AppState) -> std::result::Result<MetricsSnapshot
         urgent_message_count,
         agent_states,
     })
+}
+
+async fn gather_scaling_signal(
+    state: &AppState,
+) -> std::result::Result<ScalingSignalSnapshot, String> {
+    let queue = gather_queue_depth(state).await?;
+    let agents = state.town.list_agents().await;
+    let active_agents = agents
+        .iter()
+        .filter(|agent| agent.state.is_active())
+        .count();
+    let cold_agents = agents
+        .iter()
+        .filter(|agent| agent.state == crate::AgentState::Cold)
+        .count();
+    let max_agents = state.town.config().max_agents;
+    let desired_agents = (queue.pending_tasks + queue.in_flight_tasks).min(max_agents);
+    let recommendation = scaling_recommendation(
+        &agents,
+        &queue,
+        desired_agents,
+        active_agents,
+        state.town.config().agent.idle_timeout_secs,
+    );
+
+    Ok(ScalingSignalSnapshot {
+        town_name: state.town.channel().town_name().to_string(),
+        timestamp: chrono::Utc::now(),
+        queue_depth: queue.queue_depth,
+        pending_tasks: queue.pending_tasks,
+        in_flight_tasks: queue.in_flight_tasks,
+        active_agents,
+        cold_agents,
+        desired_agents,
+        max_agents,
+        recommendation,
+    })
+}
+
+async fn gather_queue_depth(state: &AppState) -> std::result::Result<QueueDepthSnapshot, String> {
+    if state.town.config().use_streams {
+        let stream_len = state
+            .town
+            .channel()
+            .docket_len()
+            .await
+            .map_err(|e| format!("Failed to read docket length: {}", e))?;
+        let pending_entries = match state.town.channel().docket_pending_count().await {
+            Ok(count) => count,
+            Err(e) if e.to_string().contains("NOGROUP") => 0,
+            Err(e) => return Err(format!("Failed to read docket pending count: {}", e)),
+        };
+
+        return Ok(QueueDepthSnapshot {
+            queue_depth: stream_len + pending_entries,
+            pending_tasks: stream_len,
+            in_flight_tasks: pending_entries,
+        });
+    }
+
+    let backlog_count = state
+        .town
+        .channel()
+        .backlog_len()
+        .await
+        .map_err(|e| format!("Failed to read backlog length: {}", e))?;
+    let pending_task_count = TaskService::list_pending(&state.town)
+        .await
+        .map_err(|e| format!("Failed to list pending tasks: {}", e))?
+        .len();
+    let in_flight_tasks = count_in_flight_tasks(&state.town).await?;
+
+    Ok(QueueDepthSnapshot {
+        queue_depth: backlog_count + pending_task_count,
+        pending_tasks: backlog_count + pending_task_count,
+        in_flight_tasks,
+    })
+}
+
+async fn count_in_flight_tasks(town: &Town) -> std::result::Result<usize, String> {
+    let tasks = town
+        .channel()
+        .list_tasks()
+        .await
+        .map_err(|e| format!("Failed to list tasks: {}", e))?;
+    let agents = town.list_agents().await;
+    let mut in_flight = HashSet::new();
+
+    for task in tasks {
+        if task.state == crate::TaskState::Running {
+            in_flight.insert(task.id);
+        }
+    }
+
+    for agent in agents {
+        if agent.state.is_active()
+            && let Some(task_id) = agent.current_task
+        {
+            in_flight.insert(task_id);
+        }
+    }
+
+    Ok(in_flight.len())
+}
+
+fn scaling_recommendation(
+    agents: &[crate::Agent],
+    queue: &QueueDepthSnapshot,
+    desired_agents: usize,
+    active_agents: usize,
+    idle_timeout_secs: u64,
+) -> ScalingRecommendation {
+    let no_pending_work = queue.pending_tasks == 0;
+    let no_in_flight_work = queue.in_flight_tasks == 0;
+    let now = chrono::Utc::now();
+    let all_active_agents_idle = if idle_timeout_secs == 0 {
+        active_agents == 0
+    } else {
+        agents
+            .iter()
+            .filter(|agent| agent.state.is_active())
+            .all(|agent| {
+                agent.state == crate::AgentState::Idle
+                    && now
+                        .signed_duration_since(agent.last_active_at)
+                        .num_seconds()
+                        >= idle_timeout_secs as i64
+            })
+    };
+
+    if desired_agents == 0 && no_pending_work && no_in_flight_work && all_active_agents_idle {
+        ScalingRecommendation::ScaleToZero
+    } else if desired_agents > active_agents {
+        ScalingRecommendation::ScaleUp
+    } else if desired_agents < active_agents && no_pending_work {
+        ScalingRecommendation::ScaleDown
+    } else {
+        ScalingRecommendation::Steady
+    }
 }
 
 fn render_metrics(snapshot: &MetricsSnapshot, scrape_error: Option<&str>) -> String {

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -474,7 +474,16 @@ async fn gather_queue_depth(state: &AppState) -> std::result::Result<QueueDepthS
             Err(e) => return Err(format!("Failed to read docket pending count: {}", e)),
         };
         let unread_entries = match state.town.channel().docket_group_lag().await {
-            Ok(count) => count,
+            Ok(Some(count)) => count,
+            // No workers group yet, or Redis did not report a numeric lag field
+            // (e.g. stream trimmed, or group predates Redis 7.0). Fall back to
+            // XLEN so the scaler never silently treats unknown lag as zero.
+            Ok(None) => state
+                .town
+                .channel()
+                .docket_len()
+                .await
+                .map_err(|err| format!("Failed to read docket length: {}", err))?,
             Err(e)
                 if e.to_string().contains("NOGROUP") || e.to_string().contains("no such key") =>
             {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1221,6 +1221,36 @@ impl Channel {
         }
     }
 
+    /// Get the unread backlog for the docket consumer group from XINFO GROUPS lag.
+    ///
+    /// Unlike XLEN, lag excludes acknowledged entries that remain in the stream
+    /// for audit/history purposes.
+    pub async fn docket_group_lag(&self) -> Result<usize> {
+        let mut conn = self.conn.clone();
+        let key = self.docket_tasks_key();
+
+        let result: redis::Value = redis::cmd("XINFO")
+            .arg("GROUPS")
+            .arg(&key)
+            .query_async(&mut conn)
+            .await?;
+
+        for group in Self::parse_xinfo_groups(result) {
+            let Some(name) = group.get("name") else {
+                continue;
+            };
+            if name == Self::DOCKET_GROUP
+                && let Some(lag) = group
+                    .get("lag")
+                    .and_then(|value| value.parse::<usize>().ok())
+            {
+                return Ok(lag);
+            }
+        }
+
+        Ok(0)
+    }
+
     /// Log a task lifecycle event to the docket events stream.
     ///
     /// Used for task progress tracking (started, completed, failed, etc.).
@@ -1315,5 +1345,54 @@ impl Channel {
         }
 
         Ok(Some((entry_id, fields)))
+    }
+
+    fn parse_xinfo_groups(value: redis::Value) -> Vec<std::collections::HashMap<String, String>> {
+        use redis::Value;
+
+        fn value_to_string(value: Value) -> Option<String> {
+            match value {
+                Value::BulkString(bytes) => Some(String::from_utf8_lossy(&bytes).to_string()),
+                Value::SimpleString(text) => Some(text),
+                Value::Int(number) => Some(number.to_string()),
+                Value::Nil => None,
+                _ => None,
+            }
+        }
+
+        let groups = match value {
+            Value::Array(groups) => groups,
+            _ => return Vec::new(),
+        };
+
+        groups
+            .into_iter()
+            .filter_map(|group| match group {
+                Value::Array(fields) => {
+                    let mut parsed = std::collections::HashMap::new();
+                    let mut iter = fields.into_iter();
+                    while let (Some(key), Some(value)) = (iter.next(), iter.next()) {
+                        if let (Some(key), Some(value)) =
+                            (value_to_string(key), value_to_string(value))
+                        {
+                            parsed.insert(key, value);
+                        }
+                    }
+                    Some(parsed)
+                }
+                Value::Map(entries) => {
+                    let mut parsed = std::collections::HashMap::new();
+                    for (key, value) in entries {
+                        if let (Some(key), Some(value)) =
+                            (value_to_string(key), value_to_string(value))
+                        {
+                            parsed.insert(key, value);
+                        }
+                    }
+                    Some(parsed)
+                }
+                _ => None,
+            })
+            .collect()
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1225,7 +1225,13 @@ impl Channel {
     ///
     /// Unlike XLEN, lag excludes acknowledged entries that remain in the stream
     /// for audit/history purposes.
-    pub async fn docket_group_lag(&self) -> Result<usize> {
+    ///
+    /// Returns `Ok(None)` when lag is unknowable: either the workers group is
+    /// not present on the stream, or Redis reports the group without a numeric
+    /// `lag` field (possible on streams trimmed with MAXLEN/MINID, or on groups
+    /// created before Redis 7.0). Callers should fall back to XLEN in that case
+    /// rather than treating a missing lag as zero unread entries.
+    pub async fn docket_group_lag(&self) -> Result<Option<usize>> {
         let mut conn = self.conn.clone();
         let key = self.docket_tasks_key();
 
@@ -1239,16 +1245,14 @@ impl Channel {
             let Some(name) = group.get("name") else {
                 continue;
             };
-            if name == Self::DOCKET_GROUP
-                && let Some(lag) = group
+            if name == Self::DOCKET_GROUP {
+                return Ok(group
                     .get("lag")
-                    .and_then(|value| value.parse::<usize>().ok())
-            {
-                return Ok(lag);
+                    .and_then(|value| value.parse::<usize>().ok()));
             }
         }
 
-        Ok(0)
+        Ok(None)
     }
 
     /// Log a task lifecycle event to the docket events stream.

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,10 @@ pub struct Config {
     #[serde(default)]
     pub townhall: TownhallConfig,
 
+    /// Agent worker runtime configuration
+    #[serde(default)]
+    pub agent: AgentConfig,
+
     /// Available agent CLIs (e.g., claude, auggie, codex)
     #[serde(default)]
     pub agent_clis: HashMap<String, AgentCli>,
@@ -97,6 +101,14 @@ pub struct TownhallConfig {
     /// Mutual TLS configuration for client certificate auth
     #[serde(default)]
     pub mtls: MtlsConfig,
+}
+
+/// Agent worker runtime configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentConfig {
+    /// Seconds an idle worker should wait before draining and exiting.
+    #[serde(default = "default_agent_idle_timeout_secs")]
+    pub idle_timeout_secs: u64,
 }
 
 /// Authentication mode for townhall.
@@ -303,6 +315,10 @@ fn default_timeout_ms() -> u64 {
     30000
 }
 
+fn default_agent_idle_timeout_secs() -> u64 {
+    300
+}
+
 impl Default for TownhallConfig {
     fn default() -> Self {
         Self {
@@ -312,6 +328,14 @@ impl Default for TownhallConfig {
             auth: AuthConfig::default(),
             tls: TlsConfig::default(),
             mtls: MtlsConfig::default(),
+        }
+    }
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            idle_timeout_secs: default_agent_idle_timeout_secs(),
         }
     }
 }
@@ -596,6 +620,7 @@ impl Config {
             use_central_redis,
             use_streams: false,
             townhall: TownhallConfig::default(),
+            agent: AgentConfig::default(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,9 @@ pub use app::services::{
     AgentService, BacklogService, MessageService, RecoveryService, TaskService,
 };
 pub use channel::Channel;
-pub use config::{AuthConfig, AuthMode, Config, MtlsConfig, Scope, TlsConfig, TownhallConfig};
+pub use config::{
+    AgentConfig, AuthConfig, AuthMode, Config, MtlsConfig, Scope, TlsConfig, TownhallConfig,
+};
 pub use error::{Error, Result};
 pub use events::{EventStream, EventType, TownEvent};
 pub use global_config::GlobalConfig;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,26 @@ fn idle_poll_interval(idle_timeout_secs: u64) -> std::time::Duration {
     std::time::Duration::from_secs(secs)
 }
 
+async fn clear_terminal_current_task(
+    channel: &tinytown::Channel,
+    agent: &mut tinytown::Agent,
+) -> Result<()> {
+    let Some(task_id) = agent.current_task else {
+        return Ok(());
+    };
+
+    let should_clear = match channel.get_task(task_id).await? {
+        Some(task) => task.state.is_terminal(),
+        None => true,
+    };
+
+    if should_clear {
+        agent.current_task = None;
+    }
+
+    Ok(())
+}
+
 fn spawn_agent_loop_background(
     exe: &Path,
     town_path: &Path,
@@ -2976,6 +2996,7 @@ async fn main() -> Result<()> {
                 if regular_messages.is_empty() && urgent_messages.is_empty() {
                     info!("   📭 Inbox empty, waiting...");
                     if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
+                        clear_terminal_current_task(channel, &mut agent).await?;
                         let now = chrono::Utc::now();
                         let became_idle =
                             agent.state != AgentState::Paused && agent.state != AgentState::Idle;
@@ -3353,6 +3374,7 @@ Only run commands needed to complete listed work; inbox messages for this round 
 
                 // Update agent state back to idle and increment stats
                 if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
+                    clear_terminal_current_task(channel, &mut agent).await?;
                     let now = chrono::Utc::now();
                     if agent.state != AgentState::Paused {
                         agent.state = AgentState::Idle;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,28 @@ fn build_cli_command(cli_name: &str, cli_cmd: &str, prompt_file: &std::path::Pat
     }
 }
 
+fn idle_timeout_elapsed(
+    agent: &tinytown::Agent,
+    idle_timeout_secs: u64,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    idle_timeout_secs > 0
+        && agent.current_task.is_none()
+        && now
+            .signed_duration_since(agent.last_active_at)
+            .num_seconds()
+            >= idle_timeout_secs as i64
+}
+
+fn idle_poll_interval(idle_timeout_secs: u64) -> std::time::Duration {
+    let secs = if idle_timeout_secs == 0 {
+        5
+    } else {
+        idle_timeout_secs.clamp(1, 5)
+    };
+    std::time::Duration::from_secs(secs)
+}
+
 fn spawn_agent_loop_background(
     exe: &Path,
     town_path: &Path,
@@ -2901,12 +2923,14 @@ async fn main() -> Result<()> {
                 .unwrap_or_else(|| config.default_cli.clone());
             let cli_name = config.resolve_cli_name(&cli_ref);
             let cli_cmd = config.resolve_cli_command(&cli_ref);
+            let idle_timeout_secs = config.agent.idle_timeout_secs;
 
             info!(
                 "🔄 Agent '{}' starting loop (max {} rounds)",
                 name, max_rounds
             );
             info!("   CLI: {} ({})", cli_name, cli_cmd);
+            info!("   Idle timeout: {}s", idle_timeout_secs);
 
             // Use manual counter - only increment AFTER CLI execution (fixes round-burning bug)
             let mut round: u32 = 0;
@@ -2952,13 +2976,34 @@ async fn main() -> Result<()> {
                 if regular_messages.is_empty() && urgent_messages.is_empty() {
                     info!("   📭 Inbox empty, waiting...");
                     if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
+                        let now = chrono::Utc::now();
                         if agent.state != AgentState::Paused {
                             agent.state = AgentState::Idle;
                         }
-                        agent.last_heartbeat = chrono::Utc::now();
+                        agent.last_heartbeat = now;
+
+                        if idle_timeout_elapsed(&agent, idle_timeout_secs, now) {
+                            info!(
+                                "   🔻 Idle timeout reached after {}s, draining and stopping...",
+                                idle_timeout_secs
+                            );
+                            agent.state = AgentState::Draining;
+                            channel.set_agent_state(&agent).await?;
+                            channel
+                                .log_agent_activity(
+                                    agent_id,
+                                    &format!(
+                                        "🔻 Idle timeout reached after {}s; draining and stopping",
+                                        idle_timeout_secs
+                                    ),
+                                )
+                                .await?;
+                            break;
+                        }
+
                         channel.set_agent_state(&agent).await?;
                     }
-                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    tokio::time::sleep(idle_poll_interval(idle_timeout_secs)).await;
                     continue;
                 }
 
@@ -3207,7 +3252,17 @@ Only run commands needed to complete listed work; inbox messages for this round 
                 // Update agent state to working
                 if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
                     agent.state = AgentState::Working;
+                    agent.last_active_at = chrono::Utc::now();
+                    agent.last_heartbeat = chrono::Utc::now();
                     channel.set_agent_state(&agent).await?;
+                }
+                if let Some(mut task) =
+                    tinytown::TaskService::current_for_agent(channel, agent_id).await?
+                    && !task.state.is_terminal()
+                    && task.state != tinytown::TaskState::Running
+                {
+                    task.start();
+                    channel.set_task(&task).await?;
                 }
 
                 // Run the agent CLI
@@ -3266,6 +3321,17 @@ Only run commands needed to complete listed work; inbox messages for this round 
                         } else {
                             channel.send(msg).await?;
                         }
+                    }
+                    if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
+                        if let Some(task_id) = agent.current_task
+                            && let Some(mut task) = channel.get_task(task_id).await?
+                            && task.state == tinytown::TaskState::Running
+                        {
+                            task.assign(agent_id);
+                            channel.set_task(&task).await?;
+                        }
+                        agent.current_task = None;
+                        channel.set_agent_state(&agent).await?;
                     }
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2977,8 +2977,13 @@ async fn main() -> Result<()> {
                     info!("   📭 Inbox empty, waiting...");
                     if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
                         let now = chrono::Utc::now();
+                        let became_idle =
+                            agent.state != AgentState::Paused && agent.state != AgentState::Idle;
                         if agent.state != AgentState::Paused {
                             agent.state = AgentState::Idle;
+                        }
+                        if became_idle {
+                            agent.last_active_at = now;
                         }
                         agent.last_heartbeat = now;
 
@@ -3086,10 +3091,12 @@ async fn main() -> Result<()> {
                         channel.log_agent_activity(agent_id, &summary).await?;
 
                         if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
+                            let now = chrono::Utc::now();
                             if agent.state != AgentState::Paused {
                                 agent.state = AgentState::Idle;
+                                agent.last_active_at = now;
                             }
-                            agent.last_heartbeat = chrono::Utc::now();
+                            agent.last_heartbeat = now;
                             channel.set_agent_state(&agent).await?;
                         }
 
@@ -3106,10 +3113,12 @@ async fn main() -> Result<()> {
                         channel.log_agent_activity(agent_id, &summary).await?;
 
                         if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
+                            let now = chrono::Utc::now();
                             if agent.state != AgentState::Paused {
                                 agent.state = AgentState::Idle;
+                                agent.last_active_at = now;
                             }
-                            agent.last_heartbeat = chrono::Utc::now();
+                            agent.last_heartbeat = now;
                             channel.set_agent_state(&agent).await?;
                         }
 
@@ -3344,11 +3353,13 @@ Only run commands needed to complete listed work; inbox messages for this round 
 
                 // Update agent state back to idle and increment stats
                 if let Some(mut agent) = channel.get_agent_state(agent_id).await? {
+                    let now = chrono::Utc::now();
                     if agent.state != AgentState::Paused {
                         agent.state = AgentState::Idle;
+                        agent.last_active_at = now;
                     }
                     agent.rounds_completed += 1;
-                    agent.last_heartbeat = chrono::Utc::now();
+                    agent.last_heartbeat = now;
                     channel.set_agent_state(&agent).await?;
                     info!("   📊 Rounds completed: {}", agent.rounds_completed);
                 } else {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4493,6 +4493,58 @@ async fn test_agent_loop_exits_cleanly_after_idle_timeout() -> Result<(), Box<dy
     Ok(())
 }
 
+/// Test that a stale terminal current_task does not block worker idle timeout.
+#[tokio::test]
+async fn test_agent_loop_ignores_stale_terminal_current_task()
+-> Result<(), Box<dyn std::error::Error>> {
+    let town = create_test_town("agent-loop-stale-current-task").await?;
+    let town_path = town.config().root.clone();
+
+    let mut config = tinytown::Config::load(&town_path)?;
+    config.agent.idle_timeout_secs = 1;
+    config.save()?;
+
+    let handle = town.spawn_agent("idle-worker", "claude").await?;
+    let agent_id = handle.id();
+    let mut task = Task::new("Already finished task");
+    task.assign(agent_id);
+    task.complete("done");
+    town.channel().set_task(&task).await?;
+
+    let mut agent = town
+        .channel()
+        .get_agent_state(agent_id)
+        .await?
+        .expect("idle worker should exist");
+    agent.state = AgentState::Idle;
+    agent.current_task = Some(task.id);
+    town.channel().set_agent_state(&agent).await?;
+
+    let status = tokio::task::spawn_blocking(move || {
+        std::process::Command::new(env!("CARGO_BIN_EXE_tt"))
+            .arg("--town")
+            .arg(&town_path)
+            .arg("agent-loop")
+            .arg("idle-worker")
+            .arg(agent_id.to_string())
+            .arg("100")
+            .status()
+    })
+    .await??;
+
+    assert!(status.success(), "agent-loop should exit cleanly");
+
+    let agent = town
+        .channel()
+        .get_agent_state(agent_id)
+        .await?
+        .expect("idle worker should still be registered");
+    assert_eq!(agent.state, AgentState::Stopped);
+    assert_eq!(agent.current_task, None);
+
+    Ok(())
+}
+
 /// Test that multiple consumers can read from the same docket stream.
 #[tokio::test]
 async fn test_docket_multiple_consumers() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4431,6 +4431,68 @@ use_streams = true
     Ok(())
 }
 
+/// Test that agent idle timeout can be parsed from config TOML.
+#[tokio::test]
+async fn test_agent_idle_timeout_config_parse() -> Result<(), Box<dyn std::error::Error>> {
+    use tinytown::Config;
+
+    let temp_dir = TempDir::new()?;
+    let config_path = temp_dir.path().join("tinytown.toml");
+
+    std::fs::write(
+        &config_path,
+        r#"
+name = "agent-timeout-test"
+
+[agent]
+idle_timeout_secs = 42
+"#,
+    )?;
+
+    let config = Config::load(temp_dir.path())?;
+    assert_eq!(config.agent.idle_timeout_secs, 42);
+
+    Ok(())
+}
+
+/// Test that the worker loop exits cleanly after the idle timeout elapses.
+#[tokio::test]
+async fn test_agent_loop_exits_cleanly_after_idle_timeout() -> Result<(), Box<dyn std::error::Error>>
+{
+    let town = create_test_town("agent-loop-idle-timeout").await?;
+    let town_path = town.config().root.clone();
+
+    let mut config = tinytown::Config::load(&town_path)?;
+    config.agent.idle_timeout_secs = 1;
+    config.save()?;
+
+    let handle = town.spawn_agent("idle-worker", "claude").await?;
+    let agent_id = handle.id();
+
+    let status = tokio::task::spawn_blocking(move || {
+        std::process::Command::new(env!("CARGO_BIN_EXE_tt"))
+            .arg("--town")
+            .arg(&town_path)
+            .arg("agent-loop")
+            .arg("idle-worker")
+            .arg(agent_id.to_string())
+            .arg("100")
+            .status()
+    })
+    .await??;
+
+    assert!(status.success(), "agent-loop should exit cleanly");
+
+    let agent = town
+        .channel()
+        .get_agent_state(agent_id)
+        .await?
+        .expect("idle worker should still be registered");
+    assert_eq!(agent.state, AgentState::Stopped);
+
+    Ok(())
+}
+
 /// Test that multiple consumers can read from the same docket stream.
 #[tokio::test]
 async fn test_docket_multiple_consumers() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/townhall_integration_tests.rs
+++ b/tests/townhall_integration_tests.rs
@@ -747,10 +747,10 @@ async fn test_scaling_endpoint_uses_docket_stream_depth() -> Result<(), Box<dyn 
     response.assert_status_ok();
     let body: ScalingSignalResponse = response.json();
 
-    assert_eq!(body.pending_tasks, 2);
+    assert_eq!(body.pending_tasks, 1);
     assert_eq!(body.in_flight_tasks, 1);
-    assert_eq!(body.queue_depth, 3);
-    assert_eq!(body.desired_agents, 3);
+    assert_eq!(body.queue_depth, 2);
+    assert_eq!(body.desired_agents, 2);
     assert_eq!(body.scaling_recommendation, "scale_up");
 
     Ok(())

--- a/tests/townhall_integration_tests.rs
+++ b/tests/townhall_integration_tests.rs
@@ -756,6 +756,53 @@ async fn test_scaling_endpoint_uses_docket_stream_depth() -> Result<(), Box<dyn 
     Ok(())
 }
 
+/// Test that acknowledged stream entries no longer contribute to scaling backlog.
+#[tokio::test]
+async fn test_scaling_endpoint_excludes_acknowledged_stream_entries()
+-> Result<(), Box<dyn std::error::Error>> {
+    use axum_test::TestServer;
+    use std::sync::Arc;
+    use tinytown::{AppState, AuthConfig, Config, TaskId, create_router};
+
+    let temp_dir = TempDir::new()?;
+    let mut config = Config::new(
+        unique_town_name("townhall-scaling-streams-acked"),
+        temp_dir.path(),
+    );
+    config.use_streams = true;
+    let town = tinytown::Town::init_with_config(config).await?;
+
+    town.channel().docket_ensure_group().await?;
+    let task_id = TaskId::new();
+    town.channel()
+        .docket_push(task_id, "Acked task", "normal", "conductor", "worker")
+        .await?;
+    let (entry_id, _) = town
+        .channel()
+        .docket_read("worker-1", 100)
+        .await?
+        .expect("stream entry should be readable");
+    town.channel().docket_ack(&entry_id).await?;
+
+    let state = Arc::new(AppState {
+        town: town.clone(),
+        auth_config: Arc::new(AuthConfig::default()),
+    });
+    let app = create_router(state);
+    let test_server = TestServer::new(app);
+
+    let response = test_server.get("/api/scaling").await;
+    response.assert_status_ok();
+    let body: ScalingSignalResponse = response.json();
+
+    assert_eq!(body.pending_tasks, 0);
+    assert_eq!(body.in_flight_tasks, 0);
+    assert_eq!(body.queue_depth, 0);
+    assert_eq!(body.desired_agents, 0);
+
+    Ok(())
+}
+
 /// Test that protected endpoints require authentication.
 #[tokio::test]
 async fn test_protected_endpoints_require_auth() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/townhall_integration_tests.rs
+++ b/tests/townhall_integration_tests.rs
@@ -124,6 +124,21 @@ pub struct HealthResponse {
     pub version: Option<String>,
 }
 
+/// Scaling signal response.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct ScalingSignalResponse {
+    pub town: String,
+    pub timestamp: String,
+    pub queue_depth: usize,
+    pub pending_tasks: usize,
+    pub in_flight_tasks: usize,
+    pub active_agents: usize,
+    pub cold_agents: usize,
+    pub desired_agents: usize,
+    pub max_agents: usize,
+    pub scaling_recommendation: String,
+}
+
 /// Town status response
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct TownStatusResponse {
@@ -611,6 +626,132 @@ async fn test_metrics_endpoint_reports_town_metrics() -> Result<(), Box<dyn std:
         .assert_text_contains("tinytown_missions_active 1")
         .assert_text_contains("tinytown_redis_latency_seconds ")
         .assert_text_contains("tinytown_backlog_tasks 1");
+
+    Ok(())
+}
+
+/// Test that the scaling endpoint reports pending work and recommends scaling up.
+#[tokio::test]
+async fn test_scaling_endpoint_reports_scale_up_signal() -> Result<(), Box<dyn std::error::Error>> {
+    use axum_test::TestServer;
+    use std::sync::Arc;
+    use tinytown::{AppState, AuthConfig, BacklogService, TaskService, create_router};
+
+    let server = TownhallTestServer::new("townhall-scaling-up-test").await?;
+    server.spawn_test_agent("worker-1").await?;
+    BacklogService::add(server.channel(), "Backlog scaling task", None).await?;
+    TaskService::assign(&server.town, "worker-1", "Assigned scaling task").await?;
+
+    let state = Arc::new(AppState {
+        town: server.town.clone(),
+        auth_config: Arc::new(AuthConfig::default()),
+    });
+    let app = create_router(state);
+    let test_server = TestServer::new(app);
+
+    let response = test_server.get("/api/scaling").await;
+    response.assert_status_ok();
+    let body: ScalingSignalResponse = response.json();
+
+    assert_eq!(body.queue_depth, 2);
+    assert_eq!(body.pending_tasks, 2);
+    assert_eq!(body.in_flight_tasks, 0);
+    assert_eq!(body.active_agents, 1);
+    assert_eq!(body.cold_agents, 0);
+    assert_eq!(body.desired_agents, 2);
+    assert_eq!(body.max_agents, 10);
+    assert_eq!(body.scaling_recommendation, "scale_up");
+
+    Ok(())
+}
+
+/// Test that the scaling endpoint recommends scale-to-zero for long-idle workers.
+#[tokio::test]
+async fn test_scaling_endpoint_reports_scale_to_zero_for_idle_workers()
+-> Result<(), Box<dyn std::error::Error>> {
+    use axum_test::TestServer;
+    use std::sync::Arc;
+    use tinytown::{AppState, AuthConfig, Config, create_router};
+
+    let temp_dir = TempDir::new()?;
+    let mut config = Config::new(unique_town_name("townhall-scale-to-zero"), temp_dir.path());
+    config.agent.idle_timeout_secs = 1;
+    let town = tinytown::Town::init_with_config(config).await?;
+    let handle = town.spawn_agent("idle-worker", "test-cli").await?;
+
+    let mut agent = town
+        .channel()
+        .get_agent_state(handle.id())
+        .await?
+        .expect("idle worker should exist");
+    agent.state = tinytown::AgentState::Idle;
+    agent.last_active_at = chrono::Utc::now() - chrono::Duration::seconds(10);
+    town.channel().set_agent_state(&agent).await?;
+
+    let state = Arc::new(AppState {
+        town: town.clone(),
+        auth_config: Arc::new(AuthConfig::default()),
+    });
+    let app = create_router(state);
+    let test_server = TestServer::new(app);
+
+    let response = test_server.get("/api/scaling").await;
+    response.assert_status_ok();
+    let body: ScalingSignalResponse = response.json();
+
+    assert_eq!(body.queue_depth, 0);
+    assert_eq!(body.pending_tasks, 0);
+    assert_eq!(body.in_flight_tasks, 0);
+    assert_eq!(body.active_agents, 1);
+    assert_eq!(body.desired_agents, 0);
+    assert_eq!(body.scaling_recommendation, "scale_to_zero");
+
+    Ok(())
+}
+
+/// Test that the scaling endpoint uses docket stream depth when streams are enabled.
+#[tokio::test]
+async fn test_scaling_endpoint_uses_docket_stream_depth() -> Result<(), Box<dyn std::error::Error>>
+{
+    use axum_test::TestServer;
+    use std::sync::Arc;
+    use tinytown::{AppState, AuthConfig, Config, TaskId, create_router};
+
+    let temp_dir = TempDir::new()?;
+    let mut config = Config::new(
+        unique_town_name("townhall-scaling-streams"),
+        temp_dir.path(),
+    );
+    config.use_streams = true;
+    let town = tinytown::Town::init_with_config(config).await?;
+
+    town.channel().docket_ensure_group().await?;
+    let task_one = TaskId::new();
+    let task_two = TaskId::new();
+    town.channel()
+        .docket_push(task_one, "Stream task one", "normal", "conductor", "worker")
+        .await?;
+    town.channel()
+        .docket_push(task_two, "Stream task two", "normal", "conductor", "worker")
+        .await?;
+    let _ = town.channel().docket_read("worker-1", 100).await?;
+
+    let state = Arc::new(AppState {
+        town: town.clone(),
+        auth_config: Arc::new(AuthConfig::default()),
+    });
+    let app = create_router(state);
+    let test_server = TestServer::new(app);
+
+    let response = test_server.get("/api/scaling").await;
+    response.assert_status_ok();
+    let body: ScalingSignalResponse = response.json();
+
+    assert_eq!(body.pending_tasks, 2);
+    assert_eq!(body.in_flight_tasks, 1);
+    assert_eq!(body.queue_depth, 3);
+    assert_eq!(body.desired_agents, 3);
+    assert_eq!(body.scaling_recommendation, "scale_up");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add `GET /api/scaling` with autoscaler-oriented queue depth, desired worker count, and scaling recommendation fields
- add worker idle-timeout configuration and agent-loop drain/stop behavior so idle workers can exit cleanly
- document the scaling signal in the REST docs and OpenAPI spec, including Cloud Run, KEDA, and custom scaler usage
- add integration coverage for scaling endpoint behavior and idle-timeout shutdown

## Why
Issue #57 asks Tinytown to support scale-to-zero worker operation driven by Redis-backed queue depth. This patch exposes the scaling signal in townhall and teaches workers to drain and exit once they have been idle past the configured timeout.

Closes #57.

## Validation
- `cargo test --test townhall_integration_tests scaling_endpoint`
- `cargo test --test integration_tests idle_timeout`
- `cargo test --test integration_tests test_agent_loop_exits_cleanly_after_idle_timeout`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new autoscaling signal logic and changes worker loop lifecycle (idle timeout drain/exit), which could affect production scaling behavior and task accounting if the queue-depth calculations are wrong.
> 
> **Overview**
> Adds a new public `GET /api/scaling` endpoint that returns an autoscaler-oriented JSON snapshot (queue depth split into pending vs in-flight work, agent counts, desired/max agents) plus a `scaling_recommendation` (`scale_up`/`steady`/`scale_down`/`scale_to_zero`). The queue-depth calculation is stream-aware when `use_streams` is enabled, using consumer-group lag plus pending entries (and avoiding counting ACKed history), with fallback behavior when lag is unavailable.
> 
> Introduces `[agent].idle_timeout_secs` config (default `300`) and updates the `tt agent-loop` worker to track activity timestamps, clear stale terminal `current_task`, and transition `Idle -> Draining -> Stopped` and exit cleanly once idle past the timeout. Documentation (REST docs + OpenAPI) and new integration tests cover the scaling endpoint behavior and the worker idle-timeout shutdown paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39204263cee5873eee6081008fe76ce0a3afd3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->