### PR TITLE
feat: preserve sender identity in messages

### DIFF
--- a/docs/openapi/townhall-v1.yaml
+++ b/docs/openapi/townhall-v1.yaml
@@ -1059,6 +1059,12 @@ components:
           type: string
         message:
           type: string
+        from:
+          type: string
+          description: >
+            Optional sender. Accepts an agent name, agent UUID, or the
+            "supervisor"/"conductor" alias. When omitted the message is
+            attributed to the supervisor sentinel.
         kind:
           type: string
           enum: [task, query, info, ack]

--- a/docs/src/cli/send.md
+++ b/docs/src/cli/send.md
@@ -39,10 +39,13 @@ Use this for:
 
 | Option | Description |
 |--------|-------------|
+| `--from <AGENT>` | Attribute the message to a specific sender (agent name or UUID). When omitted, defaults to the current agent context (`TINYTOWN_AGENT_ID` / `TINYTOWN_AGENT_NAME` env vars set by `tt agent-loop`) or the supervisor sentinel. |
 | `--query` | Mark message as a query (`query` semantic type) |
 | `--info` | Mark message as informational (`info` semantic type) |
 | `--ack` | Mark message as confirmation (`ack` semantic type) |
 | `--urgent` | Send as urgent (processed first at start of next round) |
+
+When an agent's CLI subprocess runs `tt send` without `--from`, the sender is automatically resolved from the `TINYTOWN_AGENT_ID` environment variable that `tt agent-loop` injects, so agent-to-agent messages carry the real sender UUID instead of the supervisor sentinel.
 
 ## Examples
 

--- a/src/app/mcp/tools.rs
+++ b/src/app/mcp/tools.rs
@@ -87,6 +87,9 @@ pub struct SendMessageInput {
     pub to: String,
     /// Message content
     pub message: String,
+    /// Optional sender agent name or UUID. Defaults to the supervisor sentinel.
+    #[serde(default)]
+    pub from: Option<String>,
     /// Message kind: "task", "query", "info", or "ack"
     #[serde(default = "default_kind")]
     pub kind: String,
@@ -1118,8 +1121,9 @@ pub fn message_send_tool(state: Arc<McpState>) -> Tool {
                     "ack" => MessageKind::Ack,
                     _ => MessageKind::Task,
                 };
-                match MessageService::send(
+                match MessageService::send_as(
                     &state.town,
+                    input.from.as_deref(),
                     &input.to,
                     &input.message,
                     kind,

--- a/src/app/server.rs
+++ b/src/app/server.rs
@@ -735,6 +735,9 @@ struct SendReq {
     to: String,
     message: String,
     kind: Option<String>,
+    /// Optional sender. Agent name or UUID; defaults to the supervisor sentinel.
+    #[serde(default)]
+    from: Option<String>,
     #[serde(default)]
     urgent: bool,
 }
@@ -749,9 +752,16 @@ async fn send_message(
         Some("ack") => MessageKind::Ack,
         _ => MessageKind::Task,
     };
-    let r = MessageService::send(&state.town, &req.to, &req.message, kind, req.urgent)
-        .await
-        .map_err(|e| ProblemDetails::internal_error(&e.to_string()))?;
+    let r = MessageService::send_as(
+        &state.town,
+        req.from.as_deref(),
+        &req.to,
+        &req.message,
+        kind,
+        req.urgent,
+    )
+    .await
+    .map_err(|e| ProblemDetails::internal_error(&e.to_string()))?;
     Ok((
         StatusCode::CREATED,
         Json(

--- a/src/app/services/messages.rs
+++ b/src/app/services/messages.rs
@@ -58,7 +58,10 @@ pub struct MessageInfo {
 pub struct MessageService;
 
 impl MessageService {
-    /// Send a message to an agent.
+    /// Send a message to an agent with `from = AgentId::supervisor()`.
+    ///
+    /// This is a thin wrapper over [`Self::send_as`] preserved for existing callers
+    /// that don't need to attribute the message to a specific sender.
     pub async fn send(
         town: &Town,
         to: &str,
@@ -66,6 +69,26 @@ impl MessageService {
         kind: MessageKind,
         urgent: bool,
     ) -> Result<SendResult> {
+        Self::send_as(town, None, to, content, kind, urgent).await
+    }
+
+    /// Send a message to an agent, optionally attributing it to a specific sender.
+    ///
+    /// `from` may be an agent name, UUID string, or the alias "supervisor"/"conductor".
+    /// When `None`, the sender defaults to [`AgentId::supervisor`].
+    pub async fn send_as(
+        town: &Town,
+        from: Option<&str>,
+        to: &str,
+        content: &str,
+        kind: MessageKind,
+        urgent: bool,
+    ) -> Result<SendResult> {
+        let from_id = match from {
+            None => AgentId::supervisor(),
+            Some(raw) => Self::resolve_agent_id(town, raw).await?,
+        };
+
         let to_handle = town.agent(to).await?;
         let to_id = to_handle.id();
         let channel = town.channel();
@@ -85,7 +108,7 @@ impl MessageService {
             },
         };
 
-        let msg = Message::new(AgentId::supervisor(), to_id, msg_type);
+        let msg = Message::new(from_id, to_id, msg_type);
         let message_id = msg.id;
 
         if urgent {
@@ -100,6 +123,18 @@ impl MessageService {
             urgent,
             kind,
         })
+    }
+
+    /// Resolve a user-supplied sender reference to an [`AgentId`].
+    ///
+    /// Accepts (in order): a full UUID, a registered agent name, or the
+    /// "supervisor"/"conductor" aliases via [`Town::agent`].
+    async fn resolve_agent_id(town: &Town, raw: &str) -> Result<AgentId> {
+        if let Ok(id) = raw.parse::<AgentId>() {
+            return Ok(id);
+        }
+        let handle = town.agent(raw).await?;
+        Ok(handle.id())
     }
 
     /// Get inbox summary for an agent.

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,39 @@ async fn resolve_agent_id_for_current_task(
     ))
 }
 
+/// Resolve the sender identity for outbound messages.
+///
+/// Resolution order:
+/// 1. Explicit `--from` value (UUID, agent name, or "supervisor"/"conductor").
+/// 2. `TINYTOWN_AGENT_ID` env var (set by `tt agent-loop` when spawning a CLI).
+/// 3. `TINYTOWN_AGENT_NAME` env var.
+/// 4. `AgentId::supervisor()` (default for user-driven `tt send`).
+async fn resolve_sender_id(
+    town: &Town,
+    explicit: Option<&str>,
+) -> Result<tinytown::AgentId> {
+    if let Some(raw) = explicit {
+        if let Ok(id) = raw.parse::<tinytown::AgentId>() {
+            return Ok(id);
+        }
+        return Ok(town.agent(raw).await?.id());
+    }
+
+    if let Ok(agent_id) = std::env::var(TT_AGENT_ID_ENV)
+        && let Ok(parsed_id) = agent_id.parse::<tinytown::AgentId>()
+    {
+        return Ok(parsed_id);
+    }
+
+    if let Ok(agent_name) = std::env::var(TT_AGENT_NAME_ENV)
+        && let Ok(handle) = town.agent(&agent_name).await
+    {
+        return Ok(handle.id());
+    }
+
+    Ok(tinytown::AgentId::supervisor())
+}
+
 fn is_supervisor_alias(name: &str) -> bool {
     matches!(name.to_lowercase().as_str(), "supervisor" | "conductor")
 }
@@ -451,6 +484,11 @@ enum Commands {
 
         /// Message content
         message: String,
+
+        /// Sender agent name or UUID. Defaults to the current agent context
+        /// (TINYTOWN_AGENT_ID / TINYTOWN_AGENT_NAME when set) or "supervisor".
+        #[arg(long)]
+        from: Option<String>,
 
         /// Mark message as a query requiring a response
         #[arg(long, conflicts_with_all = ["info", "ack"])]
@@ -2828,6 +2866,7 @@ async fn main() -> Result<()> {
         Commands::Send {
             to,
             message,
+            from,
             query,
             info: informational,
             ack,
@@ -2838,6 +2877,8 @@ async fn main() -> Result<()> {
             let town = Town::connect(&cli.town).await?;
             let to_handle = town.agent(&to).await?;
             let to_id = to_handle.id();
+
+            let from_id = resolve_sender_id(&town, from.as_deref()).await?;
 
             let (msg_type, label) = if query {
                 (MessageType::Query { question: message }, "query")
@@ -2862,14 +2903,19 @@ async fn main() -> Result<()> {
                 )
             };
 
-            let msg = Message::new(AgentId::supervisor(), to_id, msg_type);
+            let msg = Message::new(from_id, to_id, msg_type);
+            let from_note = if from_id == AgentId::supervisor() {
+                String::new()
+            } else {
+                format!(" (from {})", from_id)
+            };
 
             if urgent {
                 town.channel().send_urgent(&msg).await?;
-                info!("🚨 Sent URGENT {} message to '{}'", label, to);
+                info!("🚨 Sent URGENT {} message to '{}'{}", label, to, from_note);
             } else {
                 town.channel().send(&msg).await?;
-                info!("📤 Sent {} message to '{}'", label, to);
+                info!("📤 Sent {} message to '{}'{}", label, to, from_note);
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,10 +108,7 @@ async fn resolve_agent_id_for_current_task(
 /// 2. `TINYTOWN_AGENT_ID` env var (set by `tt agent-loop` when spawning a CLI).
 /// 3. `TINYTOWN_AGENT_NAME` env var.
 /// 4. `AgentId::supervisor()` (default for user-driven `tt send`).
-async fn resolve_sender_id(
-    town: &Town,
-    explicit: Option<&str>,
-) -> Result<tinytown::AgentId> {
+async fn resolve_sender_id(town: &Town, explicit: Option<&str>) -> Result<tinytown::AgentId> {
     if let Some(raw) = explicit {
         if let Ok(id) = raw.parse::<tinytown::AgentId>() {
             return Ok(id);

--- a/src/mission/scheduler.rs
+++ b/src/mission/scheduler.rs
@@ -533,7 +533,7 @@ impl MissionScheduler {
             .collect();
 
         // Sort by total score descending
-        scored.sort_by(|a, b| b.1.total().cmp(&a.1.total()));
+        scored.sort_by_key(|entry| std::cmp::Reverse(entry.1.total()));
 
         // Return best match if score is positive
         scored

--- a/tests/townhall_integration_tests.rs
+++ b/tests/townhall_integration_tests.rs
@@ -418,7 +418,10 @@ async fn test_services_send_as_preserves_sender() -> Result<(), Box<dyn std::err
     assert_eq!(peeked.len(), 3);
 
     let froms: Vec<_> = peeked.iter().map(|m| m.from).collect();
-    assert!(froms.contains(&sender.id()), "agent-name send should map to sender id");
+    assert!(
+        froms.contains(&sender.id()),
+        "agent-name send should map to sender id"
+    );
     assert!(
         froms.iter().filter(|&&id| id == sender.id()).count() >= 2,
         "uuid send should also map to sender id"
@@ -462,10 +465,7 @@ async fn test_townhall_send_endpoint_accepts_from() -> Result<(), Box<dyn std::e
         .assert_status(axum::http::StatusCode::CREATED);
 
     let receiver_handle = server.town.agent("receiver").await?;
-    let peeked = server
-        .channel()
-        .peek_inbox(receiver_handle.id(), 5)
-        .await?;
+    let peeked = server.channel().peek_inbox(receiver_handle.id(), 5).await?;
     assert_eq!(peeked.len(), 1);
     assert_eq!(peeked[0].from, sender.id());
 

--- a/tests/townhall_integration_tests.rs
+++ b/tests/townhall_integration_tests.rs
@@ -369,6 +369,109 @@ async fn test_services_send_message() -> Result<(), Box<dyn std::error::Error>> 
     Ok(())
 }
 
+/// Verify `MessageService::send_as` records the specified sender (agent name or UUID)
+/// instead of always attributing the message to the supervisor sentinel.
+#[tokio::test]
+async fn test_services_send_as_preserves_sender() -> Result<(), Box<dyn std::error::Error>> {
+    let server = TownhallTestServer::new("townhall-send-as-test").await?;
+    let sender = server.spawn_test_agent("sender").await?;
+    let _receiver = server.spawn_test_agent("receiver").await?;
+
+    // Send by agent name.
+    tinytown::MessageService::send_as(
+        &server.town,
+        Some("sender"),
+        "receiver",
+        "hi from sender",
+        tinytown::app::services::messages::MessageKind::Info,
+        false,
+    )
+    .await?;
+
+    // Send by UUID.
+    tinytown::MessageService::send_as(
+        &server.town,
+        Some(&sender.id().to_string()),
+        "receiver",
+        "hi again",
+        tinytown::app::services::messages::MessageKind::Info,
+        false,
+    )
+    .await?;
+
+    // Default path (no from) still uses supervisor.
+    tinytown::MessageService::send_as(
+        &server.town,
+        None,
+        "receiver",
+        "system fyi",
+        tinytown::app::services::messages::MessageKind::Info,
+        false,
+    )
+    .await?;
+
+    let receiver_handle = server.town.agent("receiver").await?;
+    let peeked = server
+        .channel()
+        .peek_inbox(receiver_handle.id(), 10)
+        .await?;
+    assert_eq!(peeked.len(), 3);
+
+    let froms: Vec<_> = peeked.iter().map(|m| m.from).collect();
+    assert!(froms.contains(&sender.id()), "agent-name send should map to sender id");
+    assert!(
+        froms.iter().filter(|&&id| id == sender.id()).count() >= 2,
+        "uuid send should also map to sender id"
+    );
+    assert!(
+        froms.contains(&tinytown::AgentId::supervisor()),
+        "default path should still produce a supervisor-attributed message"
+    );
+
+    Ok(())
+}
+
+/// Verify that `POST /v1/messages` honors an optional `from` field when provided.
+#[tokio::test]
+async fn test_townhall_send_endpoint_accepts_from() -> Result<(), Box<dyn std::error::Error>> {
+    use axum_test::TestServer;
+    use std::sync::Arc;
+    use tinytown::{AppState, AuthConfig, create_router};
+
+    let server = TownhallTestServer::new("townhall-send-from-test").await?;
+    let sender = server.spawn_test_agent("sender").await?;
+    let _receiver = server.spawn_test_agent("receiver").await?;
+
+    let auth_config = Arc::new(AuthConfig::default());
+    let state = Arc::new(AppState {
+        town: server.town.clone(),
+        auth_config,
+    });
+    let app = create_router(state);
+    let test_server = TestServer::new(app);
+
+    test_server
+        .post("/v1/messages/send")
+        .json(&serde_json::json!({
+            "to": "receiver",
+            "from": "sender",
+            "message": "hello",
+            "kind": "info"
+        }))
+        .await
+        .assert_status(axum::http::StatusCode::CREATED);
+
+    let receiver_handle = server.town.agent("receiver").await?;
+    let peeked = server
+        .channel()
+        .peek_inbox(receiver_handle.id(), 5)
+        .await?;
+    assert_eq!(peeked.len(), 1);
+    assert_eq!(peeked[0].from, sender.id());
+
+    Ok(())
+}
+
 /// Test that the inbox endpoint supports GET for read semantics while keeping POST compatibility.
 #[tokio::test]
 async fn test_townhall_inbox_endpoint_supports_get_and_post()


### PR DESCRIPTION
## Summary

Messages sent through `MessageService::send` (REST, MCP tool, and `tt send` CLI) were hard-coded to `from = AgentId::supervisor()`, so every persisted message in Redis listed the system sentinel as the sender regardless of who actually sent it. This broke dashboard chat views (all traffic looked like `system → agent`) and made any analytics that depend on the sender meaningless.

## Changes

- **`MessageService::send_as(town, from, to, …)`** — new entry point that accepts an agent name, UUID, or the `supervisor`/`conductor` alias. `send(...)` is retained as a thin wrapper with `from = None` so existing callers keep the supervisor default.
- **`tt send --from <agent>`** — optional flag. When omitted, the sender is resolved from the `TINYTOWN_AGENT_ID` / `TINYTOWN_AGENT_NAME` environment variables that `tt agent-loop` already injects into the CLI subprocess, so agent-to-agent messages automatically carry the real sender UUID without agents needing to pass `--from` explicitly.
- **REST `POST /v1/messages/send`** — `SendReq` gains an optional `from` field (agent name or UUID). OpenAPI schema updated.
- **MCP `message.send` tool** — `SendMessageInput` gains an optional `from` field.
- **Docs** — `docs/src/cli/send.md` and `docs/openapi/townhall-v1.yaml` updated.

## Tests

- `test_services_send_as_preserves_sender` — verifies name, UUID, and default (`None`) attribution paths end-to-end via the service layer.
- `test_townhall_send_endpoint_accepts_from` — verifies REST body honors `from` and persists it correctly.
- Existing `test_services_send_message` left unchanged (confirms the backward-compatible `send` wrapper still works).

All 19 townhall tests, 18 MCP tests, and 39 lib tests pass locally.

## Backwards compatibility

Fully additive. Every existing call site (`MessageService::send`, REST `POST /v1/messages/send` without `from`, MCP `message.send` without `from`) produces identical output to before — `from = AgentId::supervisor()`.

## Follow-ups (not in this PR)

- Dashboard chat UI can now render dyadic conversations once new traffic starts flowing.
- Older/legitimate supervisor paths (mission scheduler, dispatcher, watch, backlog claim) continue to use `AgentId::supervisor()` intentionally; not changed here.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core message attribution semantics across the service layer, REST endpoint, MCP tool, and CLI; incorrect resolution of `from` (name/UUID/env) could misattribute messages or break clients relying on the prior supervisor-only behavior.
> 
> **Overview**
> Outbound messaging now supports an optional **sender attribution**: `MessageService::send_as` accepts a `from` reference (agent name/UUID or `supervisor`/`conductor`) while `send` remains a backward-compatible wrapper defaulting to the supervisor sentinel.
> 
> The REST `POST /v1/messages/send` route and MCP `message.send` tool accept a new optional `from` field, and the `tt send` CLI adds `--from` plus automatic sender resolution from `TINYTOWN_AGENT_ID`/`TINYTOWN_AGENT_NAME` when invoked from `tt agent-loop`.
> 
> Docs/OpenAPI are updated accordingly, and new integration tests validate sender preservation via `send_as` and via the REST endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b99c4de957b6d7c366fa8effc9fd3a8ee2371ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->