### PR TITLE
fix(dispatcher): back off repeated mission-help prompts

### DIFF
--- a/src/mission/dispatcher.rs
+++ b/src/mission/dispatcher.rs
@@ -30,6 +30,16 @@ pub struct DispatcherConfig {
     pub tick_interval_secs: u64,
     /// Redis lease TTL for per-mission dispatcher ownership.
     pub lock_ttl_secs: u64,
+    /// Base interval between repeated "mission help needed" prompts to the
+    /// conductor when the underlying reason has not changed. The effective
+    /// interval grows exponentially with consecutive repeats (see
+    /// [`help_repeat_backoff_cap`]) so a long-stalled mission does not spam
+    /// the chat every few minutes.
+    pub help_repeat_interval_secs: u64,
+    /// Maximum multiplier applied to [`help_repeat_interval_secs`] via
+    /// exponential backoff. `attempt = 0` uses 1x, `attempt = 1` uses 2x,
+    /// and so on, capped at this value.
+    pub help_repeat_backoff_cap: u32,
 }
 
 impl Default for DispatcherConfig {
@@ -37,6 +47,11 @@ impl Default for DispatcherConfig {
         Self {
             tick_interval_secs: 30,
             lock_ttl_secs: 90,
+            // 30 minutes base interval, doubling up to 8x (≈ 4 hours) so a
+            // mission that has been blocked for a while is re-raised on a
+            // human-scale cadence instead of every few ticks.
+            help_repeat_interval_secs: 1800,
+            help_repeat_backoff_cap: 8,
         }
     }
 }
@@ -156,20 +171,30 @@ impl<G: GitHubClient> MissionDispatcher<G> {
                 }
 
                 if let Some(reason) = self.assess_help_needed(&mission).await? {
-                    let should_send = mission
-                        .dispatcher_last_help_request_at
-                        .map(|sent_at| {
-                            mission.dispatcher_last_help_request_reason.as_deref()
-                                != Some(reason.as_str())
-                                || Utc::now() - sent_at
-                                    >= Duration::seconds(
-                                        (self.config.tick_interval_secs * 6) as i64,
-                                    )
-                        })
-                        .unwrap_or(true);
+                    let reason_changed = mission.dispatcher_last_help_request_reason.as_deref()
+                        != Some(reason.as_str());
+                    let should_send = match mission.dispatcher_last_help_request_at {
+                        None => true,
+                        Some(_) if reason_changed => true,
+                        Some(sent_at) => {
+                            // Exponential backoff on repeats of the same reason so
+                            // we don't spam the conductor every few ticks for a
+                            // mission that has been blocked for hours.
+                            let attempts = mission.dispatcher_help_request_attempts;
+                            let shift = attempts.min(30);
+                            let raw_multiplier = 1u64.checked_shl(shift).unwrap_or(u64::MAX);
+                            let multiplier = raw_multiplier
+                                .min(self.config.help_repeat_backoff_cap.max(1) as u64);
+                            let interval_secs = self
+                                .config
+                                .help_repeat_interval_secs
+                                .saturating_mul(multiplier);
+                            Utc::now() - sent_at >= Duration::seconds(interval_secs as i64)
+                        }
+                    };
                     if should_send {
                         self.send_help_request(*mission_id, &reason).await?;
-                        mission.record_help_request(reason);
+                        mission.record_help_request(reason, reason_changed);
                     }
                 }
 

--- a/src/mission/scheduler.rs
+++ b/src/mission/scheduler.rs
@@ -533,7 +533,7 @@ impl MissionScheduler {
             .collect();
 
         // Sort by total score descending
-        scored.sort_by(|a, b| b.1.total().cmp(&a.1.total()));
+        scored.sort_by_key(|entry| std::cmp::Reverse(entry.1.total()));
 
         // Return best match if score is positive
         scored

--- a/src/mission/types.rs
+++ b/src/mission/types.rs
@@ -366,6 +366,12 @@ pub struct MissionRun {
     pub dispatcher_last_help_request_at: Option<DateTime<Utc>>,
     /// Most recent help-request reason sent to the conductor
     pub dispatcher_last_help_request_reason: Option<String>,
+    /// Number of consecutive repeats of the same help-request reason.
+    /// Reset to 0 when the reason changes or the dispatcher observes
+    /// mission progress. Used by the dispatcher to back off repeated
+    /// prompts to the conductor.
+    #[serde(default)]
+    pub dispatcher_help_request_attempts: u32,
 }
 
 impl MissionRun {
@@ -386,6 +392,7 @@ impl MissionRun {
             dispatcher_last_progress_at: None,
             dispatcher_last_help_request_at: None,
             dispatcher_last_help_request_reason: None,
+            dispatcher_help_request_attempts: 0,
         }
     }
 
@@ -428,14 +435,27 @@ impl MissionRun {
         let now = Utc::now();
         self.dispatcher_last_tick_at = Some(now);
         self.dispatcher_last_progress_at = Some(now);
+        // Progress means any future help request starts from a clean
+        // backoff window instead of extending the previous one.
+        self.dispatcher_help_request_attempts = 0;
         self.updated_at = now;
     }
 
     /// Record that the dispatcher escalated to the conductor.
-    pub fn record_help_request(&mut self, reason: impl Into<String>) {
+    ///
+    /// `reason_changed` indicates whether the supplied `reason` differs
+    /// from the last one sent. A fresh reason resets the backoff attempt
+    /// counter; a repeated reason increments it so the dispatcher can
+    /// apply exponential backoff between rebroadcasts.
+    pub fn record_help_request(&mut self, reason: impl Into<String>, reason_changed: bool) {
         let now = Utc::now();
         self.dispatcher_last_help_request_at = Some(now);
         self.dispatcher_last_help_request_reason = Some(reason.into());
+        self.dispatcher_help_request_attempts = if reason_changed {
+            1
+        } else {
+            self.dispatcher_help_request_attempts.saturating_add(1)
+        };
         self.updated_at = now;
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3244,6 +3244,7 @@ async fn test_mission_dispatcher_creates_fix_task_from_failing_watch()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     let result = dispatcher.tick(None).await?;
@@ -3325,6 +3326,7 @@ async fn test_mission_dispatcher_finalizes_after_successful_watch()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     let result = dispatcher.tick(None).await?;
@@ -3417,6 +3419,7 @@ async fn test_mission_dispatcher_self_resolves_clean_comment_watches()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     let result = dispatcher.tick(None).await?;
@@ -3529,6 +3532,7 @@ async fn test_mission_dispatcher_self_resolves_triggered_comment_watches()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     let first_result = dispatcher.tick(None).await?;
@@ -3573,6 +3577,7 @@ async fn test_mission_dispatcher_self_resolves_triggered_comment_watches()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     let second_result = dispatcher.tick(None).await?;
@@ -3652,6 +3657,7 @@ async fn test_mission_dispatcher_rechecks_snoozed_watch() -> Result<(), Box<dyn 
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     dispatcher.tick(None).await?;
@@ -3685,6 +3691,7 @@ async fn test_mission_dispatcher_rechecks_snoozed_watch() -> Result<(), Box<dyn 
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     dispatcher.tick(None).await?;
@@ -3758,6 +3765,7 @@ async fn test_mission_dispatcher_mergeability_respects_reviewer_gate()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     dispatcher.tick(None).await?;
@@ -3850,6 +3858,7 @@ async fn test_mission_dispatcher_escalates_to_conductor_when_stuck()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     dispatcher.tick(None).await?;
@@ -3865,6 +3874,78 @@ async fn test_mission_dispatcher_escalates_to_conductor_when_stuck()
     let updated = storage.get_mission(mission.id).await?.unwrap();
     assert!(updated.dispatcher_last_help_request_at.is_some());
     assert!(updated.dispatcher_last_help_request_reason.is_some());
+    // A fresh first escalation counts as attempt #1.
+    assert_eq!(updated.dispatcher_help_request_attempts, 1);
+
+    drop(town);
+    cleanup_redis(&temp_dir);
+    Ok(())
+}
+
+/// Verifies the dispatcher applies exponential backoff to repeated
+/// "mission help needed" prompts whose reason has not changed, and
+/// resets the attempt counter when the reason differs.
+#[tokio::test]
+async fn test_mission_dispatcher_help_request_backoff() -> Result<(), Box<dyn std::error::Error>> {
+    use tinytown::mission::{
+        DispatcherConfig, MissionDispatcher, MissionRun, MissionStorage, MockGitHubClient,
+        ObjectiveRef, WorkItem, WorkKind,
+    };
+
+    let temp_dir = TempDir::new()?;
+    let town_name = unique_town_name("mission-dispatch-backoff");
+    let town = Town::init(temp_dir.path(), &town_name).await?;
+    let storage = MissionStorage::new(town.channel().conn().clone(), &town_name);
+
+    let mut mission = MissionRun::new(vec![ObjectiveRef::Doc {
+        path: "test.md".into(),
+    }]);
+    mission.start();
+    storage.save_mission(&mission).await?;
+    storage.add_active(mission.id).await?;
+
+    let mut item = WorkItem::new(mission.id, "Implement auth", WorkKind::Implement);
+    item.mark_ready();
+    storage.save_work_item(&item).await?;
+
+    // A very large base interval guarantees the time-based branch never
+    // fires within the test, so we can assert the backoff logic purely
+    // from the attempt counter and reason-change behaviour.
+    let dispatcher = MissionDispatcher::new(
+        storage.clone(),
+        town.channel().clone(),
+        MockGitHubClient::new(),
+        DispatcherConfig {
+            tick_interval_secs: 1,
+            lock_ttl_secs: 30,
+            help_repeat_interval_secs: 86_400,
+            help_repeat_backoff_cap: 8,
+        },
+    );
+
+    dispatcher.tick(None).await?;
+    let after_first = storage.get_mission(mission.id).await?.unwrap();
+    assert_eq!(after_first.dispatcher_help_request_attempts, 1);
+
+    // Second tick with the same reason must NOT send a new prompt and
+    // must NOT bump the attempt counter (backoff window blocks resend).
+    let inbox_before = town
+        .channel()
+        .peek_inbox(AgentId::supervisor(), 50)
+        .await?
+        .len();
+    dispatcher.tick(None).await?;
+    let inbox_after = town
+        .channel()
+        .peek_inbox(AgentId::supervisor(), 50)
+        .await?
+        .len();
+    assert_eq!(
+        inbox_after, inbox_before,
+        "dispatcher should not rebroadcast within the backoff window"
+    );
+    let after_second = storage.get_mission(mission.id).await?.unwrap();
+    assert_eq!(after_second.dispatcher_help_request_attempts, 1);
 
     drop(town);
     cleanup_redis(&temp_dir);
@@ -3903,6 +3984,7 @@ async fn test_mission_dispatcher_processes_conductor_note() -> Result<(), Box<dy
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     dispatcher.tick(Some(mission.id)).await?;
@@ -3954,6 +4036,7 @@ async fn test_mission_dispatcher_ignores_resume_note_for_failed_mission()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     dispatcher.tick(Some(mission.id)).await?;
@@ -4016,6 +4099,7 @@ async fn test_mission_dispatcher_ignores_pause_note_for_blocked_mission()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     dispatcher.tick(Some(mission.id)).await?;
@@ -4094,6 +4178,7 @@ async fn test_mission_dispatcher_resume_note_completes_blocking_watches()
         DispatcherConfig {
             tick_interval_secs: 1,
             lock_ttl_secs: 30,
+            ..DispatcherConfig::default()
         },
     );
     dispatcher.tick(Some(mission.id)).await?;


### PR DESCRIPTION
## Problem

The mission dispatcher rebroadcasts `[Mission Help Needed]` prompts to the conductor every `tick_interval_secs * 6` (≈3 min at the 30s default) whenever a mission stays blocked behind an unchanged `blocked_reason`. On a mission stalled for hours this floods the conductor inbox with near-identical prompts — especially visible in the dashboard chat view, where collapsing them is currently a UI-side workaround.

## Fix

Apply exponential backoff between repeated help prompts whose reason has not changed:

- New `DispatcherConfig` fields:
  - `help_repeat_interval_secs` (default `1800` = 30 min)
  - `help_repeat_backoff_cap` (default `8` → ≈ 4 h upper bound)
- New `MissionRun.dispatcher_help_request_attempts: u32`, incremented on each repeat of the same reason and reset to `0` when either:
  - the dispatcher observes progress (`record_dispatch_progress`), or
  - the reason string changes.
- Dispatcher now sends a repeat only after `help_repeat_interval_secs * min(2^attempts, help_repeat_backoff_cap)` has elapsed since the last prompt.
- `MissionRun::record_help_request` now takes a `reason_changed` flag so the caller can drive the attempt counter correctly.

With defaults, consecutive repeats of an unchanged reason go out at roughly 30m → 1h → 2h → 4h (capped), instead of every ~3 minutes.

## Tests

- Updated `test_mission_dispatcher_escalates_to_conductor_when_stuck` to assert the first escalation registers as attempt #1.
- New `test_mission_dispatcher_help_request_backoff` exercises the no-resend-within-window path: a second tick with the same reason must neither deliver a new message to the conductor's inbox nor bump the attempt counter.
- All 12 `test_mission_dispatcher_*` tests pass locally.
- All existing `DispatcherConfig { .. }` struct literals updated to use `..DispatcherConfig::default()` for the new fields.

## Context

Paired with dashboard-side collapsing/hiding of repeated help prompts in [redis-field-engineering/tinytown-dashboard](https://github.com/redis-field-engineering/tinytown-dashboard). This PR is the upstream fix; the dashboard change stays as a defense-in-depth toggle for when operators do want to see the full history.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dispatcher escalation cadence and persists a new counter on `MissionRun`, which could alter when/if operators get prompted and requires correct serialization defaults for existing stored missions.
> 
> **Overview**
> Reduces spammy `[Mission Help Needed]` rebroadcasts by adding **exponential backoff** when the dispatcher keeps seeing the same stuck reason, with new `DispatcherConfig` knobs (`help_repeat_interval_secs`, `help_repeat_backoff_cap`).
> 
> Adds `MissionRun.dispatcher_help_request_attempts` (serde-defaulted) and updates progress/help-recording so attempts reset on observed progress or reason changes and increment on same-reason repeats; integration tests are updated and a new test asserts no resend within the backoff window. Also includes a small scheduler refactor to use `sort_by_key(Reverse(...))` for agent match ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 937be96b1334bc415cad15d342ec381bc3571058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->